### PR TITLE
fix: GitHub Pages 深層連結 SPA fallback

### DIFF
--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && rm -rf dist/textures/poc-*",
-    "build:dev": "vite build --mode development && rm -rf dist/textures/poc-*",
+    "build": "vite build && rm -rf dist/textures/poc-* && cp dist/index.html dist/404.html",
+    "build:dev": "vite build --mode development && rm -rf dist/textures/poc-* && cp dist/index.html dist/404.html",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/packages/sample/public/404.html
+++ b/packages/sample/public/404.html
@@ -1,7 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=./" />
-  </head>
-  <body></body>
-</html>


### PR DESCRIPTION
## Summary
線上 `/poc/a11`、`/poc/b10` 用網址直接開會被彈回首頁:舊 `404.html` 是「meta refresh 導回上層」的重導頁,404 → `./` → 一路退回站根。

改為標準 GitHub Pages SPA fallback:
- 刪除 `public/404.html`(meta-refresh 版)
- `build` / `build:dev` 加 `cp dist/index.html dist/404.html`——任何未知路徑由 Pages 回傳 app 本體(HTTP 仍是 404,但內容是 app),React Router 依 `basename` 渲染原網址對應頁面,網址不變

## Test plan
- [x] 本地 `npm run build`:`dist/404.html` 與 `dist/index.html` 完全一致(cmp 驗證)
- [x] 資產路徑為絕對 `/re-canvas-door-swing/assets/...`,從任意深層路徑載入皆有效
- [ ] 合併部署後驗證 `www.muji.dev/re-canvas-door-swing/poc/b10` 直接開能到 b10 頁

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback handling for sample application routes by generating a 404 page from the built application.
  * Removed the outdated static redirect page to ensure the fallback uses the latest application output.
  * Applied the updated behavior to both production and development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->