### PR TITLE
fix: correct sample-dev preview port in launch.json

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -11,7 +11,7 @@
       "name": "sample-dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 8080
+      "port": 5173
     },
     {
       "name": "sample-dev-8082",


### PR DESCRIPTION
## What changed

`.claude/launch.json` — the `sample-dev` configuration declared `"port": 8080`, changed to `5173`.

## Why

The sample app's Vite dev server is pinned to `127.0.0.1:5173` in [`packages/sample/vite.config.ts`](packages/sample/vite.config.ts), which also matches the documented `npm run dev` address in `CLAUDE.md`. The launch config pointed at 8080, so the preview tooling would start the server successfully and then fail to attach to it.

Caught while opening the PoC gallery to look at the current state of the demo site.

## Reviewer notes

- The other two entries are untouched and were already correct: `gallery-preview` (8091, static server) and `sample-dev-8082` (8082, passes `--port 8082` explicitly).
- Verified after the change: `sample-dev` starts and `http://127.0.0.1:5173/poc` renders all seven PoC entries with no console errors.
- Unrelated to this PR, but noticed while verifying: the `A04` and `C06` gallery thumbnails appear to be full-page screenshots with page text baked in, unlike the other five which are clean scene renders. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development run configuration to use port 5173.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->