### PR TITLE
Refine door variant selection API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ packages/sample/public/textures/poc-b10/
 # Claude Code 平行作業的暫存 worktree
 .claude/worktrees/
 *.tsbuildinfo
+test-results/
 __pycache__/
 # Codex CLI 本地工作目錄
 .codex/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Useful scripts:
 The door library uses layered tests to keep the core animation package
 vanilla-first while React support remains separate:
 
-- `npm run test:lib:core` covers framework-free animation state, presets, sound,
+- `npm run test:lib:core` covers framework-free animation state, variants, sound,
   and controller behavior.
 - `npm run test:lib:package` checks public package exports and verifies the
   default `retro-horror-door` entry and `retro-horror-door/vanilla` output graphs are React-free.
@@ -64,7 +64,18 @@ import { mountDoorEntrance } from "retro-horror-door";
 
 mountDoorEntrance({
   target: document.getElementById("door-root"),
-  variant: "direct-entry",
+  variant: "single-lever-wood",
+});
+```
+
+Random selection chooses from available runtime variants; it does not mix door
+parts manually:
+
+```tsx
+mountDoorEntrance({
+  target: document.getElementById("door-root"),
+  random: true,
+  type: "single",
 });
 ```
 
@@ -74,9 +85,8 @@ React adapter:
 import { DoorEntrance } from "retro-horror-door/react";
 
 <DoorEntrance
-  variant="single-top-down-entry"    // or "direct-entry"
+  variant="single-overhead-lever-wood"
   autoPlay
-  textureUrl="/textures/door-1.png"
   onComplete={() => console.log("done")}
 />;
 ```
@@ -87,6 +97,14 @@ Plain HTML:
 <div id="door-root"></div>
 <script type="module">
   import { mountDoorEntrance } from "retro-horror-door";
-  mountDoorEntrance({ target: document.getElementById("door-root"), variant: "direct-entry" });
+  mountDoorEntrance({
+    target: document.getElementById("door-root"),
+    variant: "single-lever-wood"
+  });
 </script>
 ```
+
+Runtime variant entries contain only playable library settings such as type,
+motion, handle, material, sound, and camera behavior. Source videos,
+classification notes, and thumbnail references belong in development tracking
+docs and are not shipped in the npm package.

--- a/packages/door-lib/docs/ARCHITECTURE.md
+++ b/packages/door-lib/docs/ARCHITECTURE.md
@@ -19,7 +19,8 @@ packages/door-lib/
   src/core/
     animationState.ts         # framework-free timeline -> state configs
     controller.ts             # framework-free playback lifecycle
-    presets.ts                # framework-free preset metadata
+    variants.ts               # framework-free playable variant registry
+    presets.ts                # deprecated compatibility alias for variants
     types.ts                  # shared vanilla/core types
   src/module/
     DoorEntrance.tsx          # React adapter component
@@ -64,6 +65,9 @@ export interface DoorAnimationConfig {
 ```
 - 目標契約：`DoorEntrance` 與 React-free `vanilla` renderer 應只依賴這層，適合時間軸驅動的開門動畫。
 - 目前狀態：`retro-horror-door` 預設匯出 DOM + Three.js 的 vanilla renderer；`retro-horror-door/vanilla` 保留為相容別名。兩者都不透過 React、React DOM 或 R3F 掛載；React support 應留在 `retro-horror-door/react` adapter surface。
+- 公開選門 API 使用 `variant`，例如 `single-lever-wood`。`variant` 是一個可播放門變體，內部固定 `type`、`motion`、`handleProfileId`、`material`、animation config、聲音與鏡頭行為。
+- `random: true` 只從可用 runtime variants 中挑選；`type`、`motion`、`handle`、`material` 只在 random mode 作為篩選條件。有明確 `variant` 時不能再混用這些欄位。
+- Runtime variant registry 不包含來源影片、縮圖或分類筆記。這些只存在於 Notion / gallery / dev tracking metadata，不能進 npm package。
 
 ### 2) 擴充版契約（預留，未接線）
 適用你列出的「singleSwing / doubleSwing / stairTransition…」：
@@ -108,8 +112,8 @@ export type AnimationModule = {
 ## 新增動畫的操作流程
 1) **複製 scaffold**：`src/module/animations/animation.template.ts` → 改檔名（例 `doubleSwing.ts`），填入 `id/label/description/duration/getState`。
 2) **登錄**：在 `src/module/animations/index.ts` import 並 push 到 `doorAnimationConfigs`；在 `types.ts` 的 `DoorAnimationVariant` union 加上新 id。
-3) **素材差異**：若需要不同門面/把手，透過 `DoorEntrance` 的 `textureUrl` prop 或未來的資產注入（可擴充 props）。
-4) **隨機/Seed**：在 sample 或呼叫端寫一個 picker（如 `pickVariant(seed?, blacklist?)`），選完 variant 後塞給 `DoorEntrance`。
+3) **素材差異**：新增 project-owned 或 generated asset，掛到新的 runtime variant；不要讓 runtime registry 指向來源影片、擷取影格或 gallery thumbnails。
+4) **隨機**：由 library 從 `doorEntranceVariants` 中挑選。呼叫端只能用 `random: true` 搭配分類 filter，不直接任意組合動畫、配件與材質。
 
 ## 資產與效能建議
 - 紋理：優先使用壓縮圖（webp/avif），目標單張 <300KB；模型用低 poly glTF/GLB。
@@ -122,7 +126,7 @@ vanilla-first while React integration evolves separately.
 
 ### Core Tests
 Run `npm run test:lib:core` to cover framework-free behavior: animation state,
-presets, sound scheduling, and controller lifecycle logic. These tests should
+variants, sound scheduling, and controller lifecycle logic. These tests should
 not require React, React DOM, R3F, or a browser runtime.
 
 `npm run verify:lib` and `npm run verify:lib:core` currently run the green core

--- a/packages/door-lib/src/__tests__/package-boundary.test.ts
+++ b/packages/door-lib/src/__tests__/package-boundary.test.ts
@@ -211,6 +211,15 @@ describe("package boundary", () => {
     assert.equal(vanillaExport?.require, "./dist/vanilla.cjs");
   });
 
+  it("publishes the variant registry from the root entry", () => {
+    const declaration = readFileSync(dist("index.d.ts"), "utf8");
+
+    assert.match(declaration, /doorEntranceVariants/);
+    assert.match(declaration, /getDoorEntranceVariant/);
+    assert.match(declaration, /resolveDoorEntranceVariantSelection/);
+    assert.match(declaration, /DoorEntranceVariantId/);
+  });
+
   it("keeps the full vanilla output graph React-free", () => {
     assertOutputGraphReactFree({
       label: "vanilla",

--- a/packages/door-lib/src/core/__tests__/controller.test.ts
+++ b/packages/door-lib/src/core/__tests__/controller.test.ts
@@ -8,7 +8,7 @@ describe("door entrance controller", () => {
     let completed = false;
 
     const controller = createDoorEntranceController({
-      preset: "door-single",
+      variant: "single-lever-wood",
       onProgress: (progress) => progressEvents.push(progress),
       onComplete: () => {
         completed = true;
@@ -27,7 +27,7 @@ describe("door entrance controller", () => {
     let completeCount = 0;
 
     const controller = createDoorEntranceController({
-      preset: "door-single",
+      variant: "single-lever-wood",
       onProgress: (progress) => progressEvents.push(progress),
       onComplete: () => {
         completeCount += 1;
@@ -43,25 +43,25 @@ describe("door entrance controller", () => {
     assert.equal(controller.getSnapshot().progress, 1);
   });
 
-  it("reset updates preset and progress state", () => {
+  it("reset updates variant and progress state", () => {
     const controller = createDoorEntranceController({
-      preset: "door-single",
+      variant: "single-lever-wood",
     });
 
     controller.seek(0.75);
-    controller.reset({ preset: "door-double", progress: 0.25 });
+    controller.reset({ variant: "double-lever-wood", progress: 0.25 });
 
     const snapshot = controller.getSnapshot();
 
     assert.equal(snapshot.progress, 0.25);
-    assert.equal(snapshot.preset.id, "door-double");
+    assert.equal(snapshot.variant.id, "double-lever-wood");
     assert.equal(snapshot.animation.id, "double-swing");
     assert.equal(snapshot.isPlaying, false);
   });
 
   it("stop cancels playback state", () => {
     const controller = createDoorEntranceController({
-      preset: "door-single-overhead",
+      variant: "single-overhead-lever-wood",
     });
 
     controller.play();
@@ -75,7 +75,7 @@ describe("door entrance controller", () => {
   it("restarts playback from the beginning after completion", () => {
     let completeCount = 0;
     const controller = createDoorEntranceController({
-      preset: "door-single",
+      variant: "single-lever-wood",
       onComplete: () => {
         completeCount += 1;
       },

--- a/packages/door-lib/src/core/__tests__/presets.test.ts
+++ b/packages/door-lib/src/core/__tests__/presets.test.ts
@@ -3,16 +3,16 @@ import { describe, it } from "node:test";
 import { getDoorEntrancePreset } from "../presets.ts";
 
 describe("core presets", () => {
-  it("returns the single door preset by default", () => {
+  it("maps the legacy single door preset to the default variant", () => {
     const preset = getDoorEntrancePreset("door-single");
 
-    assert.equal(preset.id, "door-single");
+    assert.equal(preset.id, "single-lever-wood");
     assert.equal(preset.variant, "direct-entry");
   });
 
-  it("falls back to the default preset for unknown values", () => {
+  it("falls back to the default variant for unknown legacy values", () => {
     const preset = getDoorEntrancePreset("missing" as never);
 
-    assert.equal(preset.id, "door-single");
+    assert.equal(preset.id, "single-lever-wood");
   });
 });

--- a/packages/door-lib/src/core/__tests__/presets.test.ts
+++ b/packages/door-lib/src/core/__tests__/presets.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { getDoorEntrancePreset } from "../presets.ts";
+import { doorEntrancePresetMap, getDoorEntrancePreset } from "../presets.ts";
 
 describe("core presets", () => {
   it("maps the legacy single door preset to the default variant", () => {
@@ -10,9 +10,14 @@ describe("core presets", () => {
     assert.equal(preset.variant, "direct-entry");
   });
 
-  it("falls back to the default variant for unknown legacy values", () => {
-    const preset = getDoorEntrancePreset("missing" as never);
+  it("exposes legacy preset aliases from the compatibility map", () => {
+    assert.equal(doorEntrancePresetMap["door-double"].id, "double-lever-wood");
+  });
 
-    assert.equal(preset.id, "single-lever-wood");
+  it("rejects unknown legacy preset values instead of falling back", () => {
+    assert.throws(
+      () => getDoorEntrancePreset("missing" as never),
+      /Unknown door entrance preset/
+    );
   });
 });

--- a/packages/door-lib/src/core/__tests__/variants.test.ts
+++ b/packages/door-lib/src/core/__tests__/variants.test.ts
@@ -45,4 +45,29 @@ describe("core door entrance variants", () => {
       /variant already defines type/
     );
   });
+
+  it("maps deprecated preset selection without treating it as a variant", () => {
+    const variant = resolveDoorEntranceVariantSelection({
+      preset: "door-double",
+    });
+
+    assert.equal(variant.id, "double-lever-wood");
+  });
+
+  it("rejects legacy preset aliases passed through variant", () => {
+    assert.throws(
+      () =>
+        resolveDoorEntranceVariantSelection({
+          variant: "door-single" as never,
+        }),
+      /Unknown door entrance variant/
+    );
+  });
+
+  it("rejects unknown variant values instead of falling back", () => {
+    assert.throws(
+      () => getDoorEntranceVariant("missing" as never),
+      /Unknown door entrance variant/
+    );
+  });
 });

--- a/packages/door-lib/src/core/__tests__/variants.test.ts
+++ b/packages/door-lib/src/core/__tests__/variants.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  doorEntranceVariants,
+  getDoorEntranceVariant,
+  resolveDoorEntranceVariantSelection,
+} from "../variants.ts";
+
+describe("core door entrance variants", () => {
+  it("returns a complete playable variant by id", () => {
+    const variant = getDoorEntranceVariant("single-lever-wood");
+
+    assert.equal(variant.id, "single-lever-wood");
+    assert.equal(variant.type, "single");
+    assert.equal(variant.motion, "hinge-single");
+    assert.equal(variant.handleProfileId, "lever-l");
+    assert.equal(variant.material, "wood-panel-aged");
+    assert.equal(variant.animation, "direct-entry");
+  });
+
+  it("keeps source references out of the runtime registry", () => {
+    for (const variant of doorEntranceVariants) {
+      assert.equal("sourceRefs" in variant, false);
+      assert.equal("thumbnailRefs" in variant, false);
+    }
+  });
+
+  it("resolves random selection from variants matching the requested type", () => {
+    const variant = resolveDoorEntranceVariantSelection(
+      { random: true, type: "double" },
+      () => 0
+    );
+
+    assert.equal(variant.id, "double-lever-wood");
+    assert.equal(variant.type, "double");
+  });
+
+  it("does not allow variant with filter fields", () => {
+    assert.throws(
+      () =>
+        resolveDoorEntranceVariantSelection({
+          variant: "single-lever-wood",
+          type: "single",
+        }),
+      /variant already defines type/
+    );
+  });
+});

--- a/packages/door-lib/src/core/controller.ts
+++ b/packages/door-lib/src/core/controller.ts
@@ -1,26 +1,27 @@
 import { getDoorAnimationConfig } from "./animationState.ts";
-import { getDoorEntrancePreset } from "./presets.ts";
+import { resolveDoorEntranceVariantSelection } from "./variants.ts";
 import type {
   DoorAnimationConfig,
   DoorAnimationState,
-  DoorEntrancePreset,
-  DoorEntrancePresetId,
+  DoorEntranceVariant,
+  DoorEntranceVariantId,
+  DoorEntranceVariantSelection,
 } from "./types.ts";
 
-export interface DoorEntranceControllerOptions {
-  preset?: DoorEntrancePresetId;
+export interface DoorEntranceControllerOptions
+  extends DoorEntranceVariantSelection {
   progress?: number;
   onProgress?: (progress: number) => void;
   onComplete?: () => void;
 }
 
 export interface DoorEntranceControllerResetOptions {
-  preset?: DoorEntrancePresetId;
+  variant?: DoorEntranceVariantId;
   progress?: number;
 }
 
 export interface DoorEntranceControllerSnapshot {
-  preset: DoorEntrancePreset;
+  variant: DoorEntranceVariant;
   animation: DoorAnimationConfig;
   progress: number;
   isPlaying: boolean;
@@ -44,28 +45,30 @@ const clampProgress = (progress: number) => {
 export const createDoorEntranceController = (
   options: DoorEntranceControllerOptions = {}
 ): DoorEntranceController => {
-  let preset = getDoorEntrancePreset(options.preset);
-  let animation = getDoorAnimationConfig(preset.variant);
+  let variant = resolveDoorEntranceVariantSelection(options);
+  let animation = getDoorAnimationConfig(variant.animation);
   let progress = clampProgress(options.progress ?? 0);
   let isPlaying = false;
   let didComplete = progress >= 1;
 
-  const syncPreset = (nextPresetId?: DoorEntrancePresetId) => {
-    preset = getDoorEntrancePreset(nextPresetId);
-    animation = getDoorAnimationConfig(preset.variant);
+  const syncVariant = (nextVariantId?: DoorEntranceVariantId) => {
+    variant = nextVariantId
+      ? resolveDoorEntranceVariantSelection({ variant: nextVariantId })
+      : variant;
+    animation = getDoorAnimationConfig(variant.animation);
   };
 
   const getSnapshot = (): DoorEntranceControllerSnapshot => {
     const easedProgress = clampProgress(animation.easing?.(progress) ?? progress);
 
     return {
-      preset,
+      variant,
       animation,
       progress,
       isPlaying,
       state: animation.getState(easedProgress, {
         linearProgress: progress,
-        handleProfileId: preset.handleProfileId,
+        handleProfileId: variant.handleProfileId,
       }),
     };
   };
@@ -87,7 +90,7 @@ export const createDoorEntranceController = (
   };
 
   const reset = (resetOptions: DoorEntranceControllerResetOptions = {}) => {
-    syncPreset(resetOptions.preset ?? preset.id);
+    syncVariant(resetOptions.variant);
     progress = clampProgress(resetOptions.progress ?? 0);
     isPlaying = false;
     didComplete = progress >= 1;

--- a/packages/door-lib/src/core/presets.ts
+++ b/packages/door-lib/src/core/presets.ts
@@ -1,33 +1,14 @@
-import type { DoorEntrancePreset, DoorEntrancePresetId } from "./types.ts";
+import {
+  doorEntranceVariantMap,
+  doorEntranceVariants,
+  getDoorEntranceVariant,
+} from "./variants.ts";
 
-export const doorEntrancePresetMap: Record<
-  DoorEntrancePresetId,
-  DoorEntrancePreset
-> = {
-  "door-single": {
-    id: "door-single",
-    label: "Door Single",
-    variant: "direct-entry",
-    handleProfileId: "lever-l",
-  },
-  "door-single-overhead": {
-    id: "door-single-overhead",
-    label: "Door Single Overhead",
-    variant: "single-top-down-entry",
-    handleProfileId: "lever-l",
-  },
-  "door-double": {
-    id: "door-double",
-    label: "Door Double",
-    variant: "double-swing",
-    handleProfileId: "lever-l",
-  },
-};
+/** @deprecated Use doorEntranceVariantMap. */
+export const doorEntrancePresetMap = doorEntranceVariantMap;
 
-export const doorEntrancePresets: DoorEntrancePreset[] = Object.values(
-  doorEntrancePresetMap
-);
+/** @deprecated Use doorEntranceVariants. */
+export const doorEntrancePresets = doorEntranceVariants;
 
-export const getDoorEntrancePreset = (
-  preset: DoorEntrancePresetId = "door-single"
-) => doorEntrancePresetMap[preset] ?? doorEntrancePresets[0];
+/** @deprecated Use getDoorEntranceVariant. */
+export const getDoorEntrancePreset = getDoorEntranceVariant;

--- a/packages/door-lib/src/core/presets.ts
+++ b/packages/door-lib/src/core/presets.ts
@@ -2,13 +2,30 @@ import {
   doorEntranceVariantMap,
   doorEntranceVariants,
   getDoorEntranceVariant,
+  legacyDoorEntrancePresetAliasMap,
+  resolveDoorEntrancePresetId,
 } from "./variants.ts";
+import type { DoorEntrancePreset, DoorEntrancePresetId } from "./types.ts";
 
 /** @deprecated Use doorEntranceVariantMap. */
-export const doorEntrancePresetMap = doorEntranceVariantMap;
+export const doorEntrancePresetMap: Record<
+  DoorEntrancePresetId,
+  DoorEntrancePreset
+> = {
+  ...doorEntranceVariantMap,
+  "door-single":
+    doorEntranceVariantMap[legacyDoorEntrancePresetAliasMap["door-single"]],
+  "door-single-overhead":
+    doorEntranceVariantMap[
+      legacyDoorEntrancePresetAliasMap["door-single-overhead"]
+    ],
+  "door-double":
+    doorEntranceVariantMap[legacyDoorEntrancePresetAliasMap["door-double"]],
+};
 
 /** @deprecated Use doorEntranceVariants. */
 export const doorEntrancePresets = doorEntranceVariants;
 
 /** @deprecated Use getDoorEntranceVariant. */
-export const getDoorEntrancePreset = getDoorEntranceVariant;
+export const getDoorEntrancePreset = (preset?: DoorEntrancePresetId) =>
+  getDoorEntranceVariant(resolveDoorEntrancePresetId(preset));

--- a/packages/door-lib/src/core/types.ts
+++ b/packages/door-lib/src/core/types.ts
@@ -49,7 +49,9 @@ export type DoorEntrancePresetId = DoorEntranceVariantId | LegacyDoorEntrancePre
 export type DoorEntrancePreset = DoorEntranceVariant;
 
 export interface DoorEntranceVariantSelection {
-  variant?: DoorEntranceVariantId | LegacyDoorEntrancePresetId;
+  variant?: DoorEntranceVariantId;
+  /** @deprecated Use variant. */
+  preset?: DoorEntrancePresetId;
   random?: boolean;
   type?: DoorEntranceType;
   motion?: DoorEntranceMotion;

--- a/packages/door-lib/src/core/types.ts
+++ b/packages/door-lib/src/core/types.ts
@@ -7,20 +7,54 @@ export type DoorAnimationVariant =
 
 export type HandleProfileId = "lever-l" | "knob-round";
 
-export type DoorEntrancePresetId =
+export type DoorEntranceType = "single" | "double";
+
+export type DoorEntranceMotion =
+  | "hinge-single"
+  | "hinge-single-overhead"
+  | "hinge-double";
+
+export type DoorMaterialId = "wood-panel-aged";
+
+export type DoorEntranceVariantId =
+  | "single-lever-wood"
+  | "single-overhead-lever-wood"
+  | "double-lever-wood";
+
+export type LegacyDoorEntrancePresetId =
   | "door-single"
   | "door-single-overhead"
   | "door-double";
 
-export interface DoorEntrancePreset {
-  id: DoorEntrancePresetId;
+export interface DoorEntranceVariant {
+  id: DoorEntranceVariantId;
   label: string;
+  type: DoorEntranceType;
+  motion: DoorEntranceMotion;
+  material: DoorMaterialId;
+  animation: DoorAnimationVariant;
+  /** @deprecated Use animation. Kept for preset compatibility only. */
   variant: DoorAnimationVariant;
   textureUrl?: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
   soundUrl?: string;
   className?: string;
+}
+
+/** @deprecated Use DoorEntranceVariantId. */
+export type DoorEntrancePresetId = DoorEntranceVariantId | LegacyDoorEntrancePresetId;
+
+/** @deprecated Use DoorEntranceVariant. */
+export type DoorEntrancePreset = DoorEntranceVariant;
+
+export interface DoorEntranceVariantSelection {
+  variant?: DoorEntranceVariantId | LegacyDoorEntrancePresetId;
+  random?: boolean;
+  type?: DoorEntranceType;
+  motion?: DoorEntranceMotion;
+  handle?: HandleProfileId;
+  material?: DoorMaterialId;
 }
 
 export interface DoorAnimationState {

--- a/packages/door-lib/src/core/variants.ts
+++ b/packages/door-lib/src/core/variants.ts
@@ -1,4 +1,5 @@
 import type {
+  DoorEntrancePresetId,
   DoorEntranceVariant,
   DoorEntranceVariantId,
   DoorEntranceVariantSelection,
@@ -43,7 +44,10 @@ export const doorEntranceVariantMap: Record<
   },
 };
 
-const legacyPresetAliasMap: Record<LegacyDoorEntrancePresetId, DoorEntranceVariantId> = {
+export const legacyDoorEntrancePresetAliasMap: Record<
+  LegacyDoorEntrancePresetId,
+  DoorEntranceVariantId
+> = {
   "door-single": "single-lever-wood",
   "door-single-overhead": "single-overhead-lever-wood",
   "door-double": "double-lever-wood",
@@ -54,19 +58,34 @@ export const doorEntranceVariants: DoorEntranceVariant[] = Object.values(
 );
 
 export const resolveDoorEntranceVariantId = (
-  variant?: DoorEntranceVariantId | LegacyDoorEntrancePresetId
+  variant?: DoorEntranceVariantId
 ): DoorEntranceVariantId => {
   if (!variant) return DEFAULT_VARIANT_ID;
 
-  return (
-    doorEntranceVariantMap[variant as DoorEntranceVariantId]?.id ??
-    legacyPresetAliasMap[variant as LegacyDoorEntrancePresetId] ??
-    DEFAULT_VARIANT_ID
-  );
+  if (doorEntranceVariantMap[variant]) return variant;
+
+  throw new Error(`Unknown door entrance variant: ${variant}`);
+};
+
+export const resolveDoorEntrancePresetId = (
+  preset?: DoorEntrancePresetId
+): DoorEntranceVariantId => {
+  if (!preset) return DEFAULT_VARIANT_ID;
+
+  if (doorEntranceVariantMap[preset as DoorEntranceVariantId]) {
+    return preset as DoorEntranceVariantId;
+  }
+
+  const variant = legacyDoorEntrancePresetAliasMap[
+    preset as LegacyDoorEntrancePresetId
+  ];
+  if (variant) return variant;
+
+  throw new Error(`Unknown door entrance preset: ${preset}`);
 };
 
 export const getDoorEntranceVariant = (
-  variant?: DoorEntranceVariantId | LegacyDoorEntrancePresetId
+  variant?: DoorEntranceVariantId
 ) => doorEntranceVariantMap[resolveDoorEntranceVariantId(variant)];
 
 const hasFilterFields = (selection: DoorEntranceVariantSelection) =>
@@ -79,6 +98,10 @@ export const resolveDoorEntranceVariantSelection = (
   selection: DoorEntranceVariantSelection = {},
   random = Math.random
 ): DoorEntranceVariant => {
+  if (selection.variant && selection.preset) {
+    throw new Error("Use variant or preset, not both.");
+  }
+
   if (selection.variant) {
     if (hasFilterFields(selection)) {
       throw new Error(
@@ -87,6 +110,16 @@ export const resolveDoorEntranceVariantSelection = (
     }
 
     return getDoorEntranceVariant(selection.variant);
+  }
+
+  if (selection.preset) {
+    if (hasFilterFields(selection)) {
+      throw new Error(
+        "preset already defines type, motion, handle, and material. Remove filter fields or use random selection."
+      );
+    }
+
+    return doorEntranceVariantMap[resolveDoorEntrancePresetId(selection.preset)];
   }
 
   if (!selection.random) {

--- a/packages/door-lib/src/core/variants.ts
+++ b/packages/door-lib/src/core/variants.ts
@@ -1,0 +1,119 @@
+import type {
+  DoorEntranceVariant,
+  DoorEntranceVariantId,
+  DoorEntranceVariantSelection,
+  LegacyDoorEntrancePresetId,
+} from "./types.ts";
+
+const DEFAULT_VARIANT_ID: DoorEntranceVariantId = "single-lever-wood";
+
+export const doorEntranceVariantMap: Record<
+  DoorEntranceVariantId,
+  DoorEntranceVariant
+> = {
+  "single-lever-wood": {
+    id: "single-lever-wood",
+    label: "Single Lever Wood",
+    type: "single",
+    motion: "hinge-single",
+    material: "wood-panel-aged",
+    animation: "direct-entry",
+    variant: "direct-entry",
+    handleProfileId: "lever-l",
+  },
+  "single-overhead-lever-wood": {
+    id: "single-overhead-lever-wood",
+    label: "Single Overhead Lever Wood",
+    type: "single",
+    motion: "hinge-single-overhead",
+    material: "wood-panel-aged",
+    animation: "single-top-down-entry",
+    variant: "single-top-down-entry",
+    handleProfileId: "lever-l",
+  },
+  "double-lever-wood": {
+    id: "double-lever-wood",
+    label: "Double Lever Wood",
+    type: "double",
+    motion: "hinge-double",
+    material: "wood-panel-aged",
+    animation: "double-swing",
+    variant: "double-swing",
+    handleProfileId: "lever-l",
+  },
+};
+
+const legacyPresetAliasMap: Record<LegacyDoorEntrancePresetId, DoorEntranceVariantId> = {
+  "door-single": "single-lever-wood",
+  "door-single-overhead": "single-overhead-lever-wood",
+  "door-double": "double-lever-wood",
+};
+
+export const doorEntranceVariants: DoorEntranceVariant[] = Object.values(
+  doorEntranceVariantMap
+);
+
+export const resolveDoorEntranceVariantId = (
+  variant?: DoorEntranceVariantId | LegacyDoorEntrancePresetId
+): DoorEntranceVariantId => {
+  if (!variant) return DEFAULT_VARIANT_ID;
+
+  return (
+    doorEntranceVariantMap[variant as DoorEntranceVariantId]?.id ??
+    legacyPresetAliasMap[variant as LegacyDoorEntrancePresetId] ??
+    DEFAULT_VARIANT_ID
+  );
+};
+
+export const getDoorEntranceVariant = (
+  variant?: DoorEntranceVariantId | LegacyDoorEntrancePresetId
+) => doorEntranceVariantMap[resolveDoorEntranceVariantId(variant)];
+
+const hasFilterFields = (selection: DoorEntranceVariantSelection) =>
+  selection.type !== undefined ||
+  selection.motion !== undefined ||
+  selection.handle !== undefined ||
+  selection.material !== undefined;
+
+export const resolveDoorEntranceVariantSelection = (
+  selection: DoorEntranceVariantSelection = {},
+  random = Math.random
+): DoorEntranceVariant => {
+  if (selection.variant) {
+    if (hasFilterFields(selection)) {
+      throw new Error(
+        "variant already defines type, motion, handle, and material. Remove filter fields or use random selection."
+      );
+    }
+
+    return getDoorEntranceVariant(selection.variant);
+  }
+
+  if (!selection.random) {
+    return getDoorEntranceVariant();
+  }
+
+  const candidates = doorEntranceVariants.filter((variant) => {
+    if (selection.type && variant.type !== selection.type) return false;
+    if (selection.motion && variant.motion !== selection.motion) return false;
+    if (selection.handle && variant.handleProfileId !== selection.handle) {
+      return false;
+    }
+    if (selection.material && variant.material !== selection.material) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (candidates.length === 0) {
+    throw new Error("No door entrance variants match the requested filters.");
+  }
+
+  const index = Math.min(
+    Math.floor(Math.max(random(), 0) * candidates.length),
+    candidates.length - 1
+  );
+
+  return candidates[index];
+};

--- a/packages/door-lib/src/index.ts
+++ b/packages/door-lib/src/index.ts
@@ -15,13 +15,25 @@ export {
   doorEntrancePresetMap,
   getDoorEntrancePreset,
 } from "./core/presets.ts";
+export {
+  doorEntranceVariantMap,
+  doorEntranceVariants,
+  getDoorEntranceVariant,
+  resolveDoorEntranceVariantSelection,
+} from "./core/variants.ts";
 export type {
   DoorAnimationConfig,
   DoorAnimationState,
   DoorAnimationVariant,
+  DoorEntranceMotion,
   DoorEntrancePreset,
   DoorEntrancePresetId,
+  DoorEntranceType,
+  DoorEntranceVariant,
+  DoorEntranceVariantId,
+  DoorEntranceVariantSelection,
   DoorEntranceSoundState,
+  DoorMaterialId,
   HandleProfileId,
   Vector3Tuple,
 } from "./core/types.ts";

--- a/packages/door-lib/src/module/DoorEntrance.tsx
+++ b/packages/door-lib/src/module/DoorEntrance.tsx
@@ -20,7 +20,6 @@ import {
   DoorAnimationRenderer,
   DoorAnimationState,
   DoorEntrancePresetId,
-  DoorAnimationVariant,
   DoorEntranceHandle,
   DoorEntranceSoundState,
   HandleProfileId,
@@ -29,8 +28,9 @@ import { getHandleProfile } from "./handles/profiles";
 import { doorWood } from "../assets/textures";
 
 interface DoorEntranceProps {
+  /** @deprecated Use variant. */
   preset?: DoorEntrancePresetId;
-  variant?: DoorAnimationVariant;
+  variant?: DoorEntrancePresetId;
   autoPlay?: boolean;
   className?: string;
   onComplete?: () => void;
@@ -142,7 +142,7 @@ const Scene = ({
 const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
   (
     {
-      preset = "door-single",
+      preset,
       variant,
       autoPlay = true,
       className,
@@ -159,18 +159,18 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
     },
     ref
   ) => {
-    const [activePreset, setActivePreset] = useState<DoorEntrancePresetId>(
-      preset
-    );
+    const selectedVariantId = variant ?? preset ?? "single-lever-wood";
+    const [activePreset, setActivePreset] =
+      useState<DoorEntrancePresetId>(selectedVariantId);
     useEffect(() => {
-      setActivePreset(preset);
-    }, [preset]);
+      setActivePreset(selectedVariantId);
+    }, [selectedVariantId]);
 
     const selectedPreset = useMemo(
       () => getDoorEntrancePreset(activePreset),
       [activePreset]
     );
-    const resolvedVariant = variant ?? selectedPreset.variant;
+    const resolvedAnimation = selectedPreset.animation;
     const resolvedTextureUrl =
       textureUrl ?? selectedPreset.textureUrl ?? DEFAULT_TEXTURE_URL;
     const resolvedHandleProfileId =
@@ -187,8 +187,8 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
       className ?? selectedPreset.className ?? DEFAULT_CLASS_NAME;
 
     const selectedConfig = useMemo(
-      () => getDoorAnimationConfig(resolvedVariant),
-      [resolvedVariant]
+      () => getDoorAnimationConfig(resolvedAnimation),
+      [resolvedAnimation]
     );
     const Renderer =
       doorAnimationRenderers[selectedConfig.id] ??
@@ -460,9 +460,9 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
     const resolveConfig = useCallback(
       (nextPreset?: DoorEntrancePresetId) =>
         getDoorAnimationConfig(
-          variant ?? getDoorEntrancePreset(nextPreset ?? activePreset).variant
+          getDoorEntrancePreset(nextPreset ?? activePreset).animation
         ),
-      [activePreset, variant]
+      [activePreset]
     );
 
     const applyProgress = useCallback(
@@ -679,7 +679,7 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
         </Canvas>
 
         <div className="pointer-events-none absolute bottom-3 right-3 rounded-full bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.08em] text-white/70 backdrop-blur">
-          {doorAnimationConfigs.find((c) => c.id === resolvedVariant)?.label ??
+          {doorAnimationConfigs.find((c) => c.id === resolvedAnimation)?.label ??
             "Door"}
         </div>
 

--- a/packages/door-lib/src/module/DoorEntrance.tsx
+++ b/packages/door-lib/src/module/DoorEntrance.tsx
@@ -20,6 +20,7 @@ import {
   DoorAnimationRenderer,
   DoorAnimationState,
   DoorEntrancePresetId,
+  DoorEntranceVariantId,
   DoorEntranceHandle,
   DoorEntranceSoundState,
   HandleProfileId,
@@ -30,7 +31,7 @@ import { doorWood } from "../assets/textures";
 interface DoorEntranceProps {
   /** @deprecated Use variant. */
   preset?: DoorEntrancePresetId;
-  variant?: DoorEntrancePresetId;
+  variant?: DoorEntranceVariantId;
   autoPlay?: boolean;
   className?: string;
   onComplete?: () => void;

--- a/packages/door-lib/src/module/index.ts
+++ b/packages/door-lib/src/module/index.ts
@@ -5,7 +5,12 @@ export type {
   DoorAnimationConfig,
   DoorEntrancePreset,
   DoorEntrancePresetId,
+  DoorEntranceMotion,
+  DoorEntranceType,
+  DoorEntranceVariant,
+  DoorEntranceVariantId,
   DoorEntranceSoundState,
+  DoorMaterialId,
   HandleProfileId,
 } from "./types";
 export type { DoorEntranceProps } from "./DoorEntrance";
@@ -20,6 +25,11 @@ export {
   doorEntrancePresets,
   doorEntrancePresetMap,
   getDoorEntrancePreset,
+} from "./presets";
+export {
+  doorEntrancePresets as doorEntranceVariants,
+  doorEntrancePresetMap as doorEntranceVariantMap,
+  getDoorEntrancePreset as getDoorEntranceVariant,
 } from "./presets";
 export {
   textureManifest,

--- a/packages/door-lib/src/module/presets.ts
+++ b/packages/door-lib/src/module/presets.ts
@@ -8,7 +8,10 @@ import {
   getHandleProfile,
 } from "./handles/profiles";
 import { doorEntrancePresets as coreDoorEntrancePresets } from "../core/presets.ts";
-import { resolveDoorEntranceVariantId } from "../core/variants.ts";
+import {
+  legacyDoorEntrancePresetAliasMap,
+  resolveDoorEntrancePresetId,
+} from "../core/variants.ts";
 import { doorWood } from "../assets/textures";
 import { doorOpenClose } from "../assets/sounds";
 
@@ -18,7 +21,7 @@ const DEFAULT_HANDLE_MODEL = getHandleProfile(
 ).defaultModelUrl;
 const DEFAULT_SINGLE_DOOR_SOUND = doorOpenClose;
 
-export const doorEntrancePresetMap: Record<
+const doorEntranceVariantPresetMap: Record<
   DoorEntranceVariantId,
   DoorEntrancePreset
 > = Object.fromEntries(
@@ -34,13 +37,28 @@ export const doorEntrancePresetMap: Record<
   ])
 ) as Record<DoorEntranceVariantId, DoorEntrancePreset>;
 
+export const doorEntrancePresetMap: Record<
+  DoorEntrancePresetId,
+  DoorEntrancePreset
+> = {
+  ...doorEntranceVariantPresetMap,
+  "door-single":
+    doorEntranceVariantPresetMap[legacyDoorEntrancePresetAliasMap["door-single"]],
+  "door-single-overhead":
+    doorEntranceVariantPresetMap[
+      legacyDoorEntrancePresetAliasMap["door-single-overhead"]
+    ],
+  "door-double":
+    doorEntranceVariantPresetMap[legacyDoorEntrancePresetAliasMap["door-double"]],
+};
+
 export const doorEntrancePresets: DoorEntrancePreset[] = Object.values(
-  doorEntrancePresetMap
+  doorEntranceVariantPresetMap
 );
 
 export const getDoorEntrancePreset = (
   preset: DoorEntrancePresetId = "single-lever-wood"
 ) =>
   doorEntrancePresetMap[
-    resolveDoorEntranceVariantId(preset) as DoorEntranceVariantId
+    resolveDoorEntrancePresetId(preset) as DoorEntranceVariantId
   ] ?? doorEntrancePresets[0];

--- a/packages/door-lib/src/module/presets.ts
+++ b/packages/door-lib/src/module/presets.ts
@@ -1,9 +1,14 @@
-import { DoorEntrancePreset, DoorEntrancePresetId } from "./types";
+import {
+  DoorEntrancePreset,
+  DoorEntrancePresetId,
+  DoorEntranceVariantId,
+} from "./types";
 import {
   DEFAULT_HANDLE_PROFILE_ID,
   getHandleProfile,
 } from "./handles/profiles";
 import { doorEntrancePresets as coreDoorEntrancePresets } from "../core/presets.ts";
+import { resolveDoorEntranceVariantId } from "../core/variants.ts";
 import { doorWood } from "../assets/textures";
 import { doorOpenClose } from "../assets/sounds";
 
@@ -14,7 +19,7 @@ const DEFAULT_HANDLE_MODEL = getHandleProfile(
 const DEFAULT_SINGLE_DOOR_SOUND = doorOpenClose;
 
 export const doorEntrancePresetMap: Record<
-  DoorEntrancePresetId,
+  DoorEntranceVariantId,
   DoorEntrancePreset
 > = Object.fromEntries(
   coreDoorEntrancePresets.map((preset) => [
@@ -27,12 +32,15 @@ export const doorEntrancePresetMap: Record<
       soundUrl: preset.soundUrl ?? DEFAULT_SINGLE_DOOR_SOUND,
     },
   ])
-) as Record<DoorEntrancePresetId, DoorEntrancePreset>;
+) as Record<DoorEntranceVariantId, DoorEntrancePreset>;
 
 export const doorEntrancePresets: DoorEntrancePreset[] = Object.values(
   doorEntrancePresetMap
 );
 
 export const getDoorEntrancePreset = (
-  preset: DoorEntrancePresetId = "door-single"
-) => doorEntrancePresetMap[preset] ?? doorEntrancePresets[0];
+  preset: DoorEntrancePresetId = "single-lever-wood"
+) =>
+  doorEntrancePresetMap[
+    resolveDoorEntranceVariantId(preset) as DoorEntranceVariantId
+  ] ?? doorEntrancePresets[0];

--- a/packages/door-lib/src/module/types.ts
+++ b/packages/door-lib/src/module/types.ts
@@ -8,14 +8,33 @@ export type DoorAnimationVariant =
 
 export type HandleProfileId = "lever-l" | "knob-round";
 
-export type DoorEntrancePresetId =
+export type DoorEntranceType = "single" | "double";
+
+export type DoorEntranceMotion =
+  | "hinge-single"
+  | "hinge-single-overhead"
+  | "hinge-double";
+
+export type DoorMaterialId = "wood-panel-aged";
+
+export type DoorEntranceVariantId =
+  | "single-lever-wood"
+  | "single-overhead-lever-wood"
+  | "double-lever-wood";
+
+export type LegacyDoorEntrancePresetId =
   | "door-single"
   | "door-single-overhead"
   | "door-double";
 
-export interface DoorEntrancePreset {
-  id: DoorEntrancePresetId;
+export interface DoorEntranceVariant {
+  id: DoorEntranceVariantId;
   label: string;
+  type: DoorEntranceType;
+  motion: DoorEntranceMotion;
+  material: DoorMaterialId;
+  animation: DoorAnimationVariant;
+  /** @deprecated Use animation. Kept for preset compatibility only. */
   variant: DoorAnimationVariant;
   textureUrl?: string;
   handleModelUrl?: string;
@@ -23,6 +42,12 @@ export interface DoorEntrancePreset {
   soundUrl?: string;
   className?: string;
 }
+
+/** @deprecated Use DoorEntranceVariantId. */
+export type DoorEntrancePresetId = DoorEntranceVariantId | LegacyDoorEntrancePresetId;
+
+/** @deprecated Use DoorEntranceVariant. */
+export type DoorEntrancePreset = DoorEntranceVariant;
 
 export interface DoorAnimationState {
   doorAngle: number;
@@ -66,10 +91,10 @@ export interface DoorEntranceSoundState {
 }
 
 export interface DoorEntranceHandle {
-  play: (preset?: DoorEntrancePresetId) => void;
+  play: (variant?: DoorEntrancePresetId) => void;
   stop: () => void;
-  reset: (preset?: DoorEntrancePresetId) => void;
-  seek: (progress: number, preset?: DoorEntrancePresetId) => void;
+  reset: (variant?: DoorEntrancePresetId) => void;
+  seek: (progress: number, variant?: DoorEntrancePresetId) => void;
   seekSound: (progress: number) => void;
 }
 

--- a/packages/door-lib/src/module/vanilla.tsx
+++ b/packages/door-lib/src/module/vanilla.tsx
@@ -2,7 +2,6 @@ import { createRoot, Root } from "react-dom/client";
 import DoorEntrance from "./DoorEntrance";
 import {
   DoorEntrancePresetId,
-  DoorAnimationVariant,
   DoorEntranceHandle,
   DoorEntranceSoundState,
   HandleProfileId,
@@ -10,8 +9,9 @@ import {
 
 interface MountDoorEntranceOptions {
   target: HTMLElement | null;
+  /** @deprecated Use variant. */
   preset?: DoorEntrancePresetId;
-  variant?: DoorAnimationVariant;
+  variant?: DoorEntrancePresetId;
   autoPlay?: boolean;
   className?: string;
   onComplete?: () => void;

--- a/packages/door-lib/src/module/vanilla.tsx
+++ b/packages/door-lib/src/module/vanilla.tsx
@@ -1,6 +1,7 @@
 import { createRoot, Root } from "react-dom/client";
 import DoorEntrance from "./DoorEntrance";
 import {
+  DoorEntranceVariantId,
   DoorEntrancePresetId,
   DoorEntranceHandle,
   DoorEntranceSoundState,
@@ -11,7 +12,7 @@ interface MountDoorEntranceOptions {
   target: HTMLElement | null;
   /** @deprecated Use variant. */
   preset?: DoorEntrancePresetId;
-  variant?: DoorEntrancePresetId;
+  variant?: DoorEntranceVariantId;
   autoPlay?: boolean;
   className?: string;
   onComplete?: () => void;

--- a/packages/door-lib/src/vanilla.ts
+++ b/packages/door-lib/src/vanilla.ts
@@ -1,21 +1,24 @@
 import * as THREE from "three";
 import { getDoorAnimationConfig } from "./core/animationState.ts";
-import { getDoorEntrancePreset } from "./core/presets.ts";
+import { resolveDoorEntranceVariantSelection } from "./core/variants.ts";
 import type {
   DoorAnimationState,
   DoorAnimationConfig,
   DoorAnimationVariant,
-  DoorEntrancePresetId,
+  DoorEntranceMotion,
   DoorEntranceSoundState,
+  DoorEntranceType,
+  DoorEntranceVariant,
+  DoorEntranceVariantId,
+  DoorEntranceVariantSelection,
+  DoorMaterialId,
   HandleProfileId,
 } from "./core/types.ts";
 import { doorWood } from "./assets/textures";
 import { doorOpenClose } from "./assets/sounds";
 
-interface MountDoorEntranceOptions {
+interface MountDoorEntranceOptions extends DoorEntranceVariantSelection {
   target: HTMLElement | null;
-  preset?: DoorEntrancePresetId;
-  variant?: DoorAnimationVariant;
   autoPlay?: boolean;
   className?: string;
   onComplete?: () => void;
@@ -24,17 +27,16 @@ interface MountDoorEntranceOptions {
   onReady?: () => void;
   textureUrl?: string;
   handleModelUrl?: string;
-  handleProfileId?: HandleProfileId;
   soundUrl?: string;
   cameraPanX?: number;
   cameraPanY?: number;
 }
 
 interface MountedDoorEntrance {
-  play: (preset?: DoorEntrancePresetId) => void;
+  play: (variant?: DoorEntranceVariantId) => void;
   stop: () => void;
-  reset: (preset?: DoorEntrancePresetId) => void;
-  seek: (progress: number, preset?: DoorEntrancePresetId) => void;
+  reset: (variant?: DoorEntranceVariantId) => void;
+  seek: (progress: number, variant?: DoorEntranceVariantId) => void;
   seekSound: (progress: number) => void;
   unmount: () => void;
 }
@@ -396,8 +398,8 @@ export const mountDoorEntrance = (
     throw new Error("mountDoorEntrance: target element is required");
   }
 
-  let activePreset = getDoorEntrancePreset(options.preset);
-  let activeConfig = getDoorAnimationConfig(options.variant ?? activePreset.variant);
+  let activeDoorVariant = resolveDoorEntranceVariantSelection(options);
+  let activeConfig = getDoorAnimationConfig(activeDoorVariant.animation);
   let progress = 0;
   let isAnimating = false;
   let didComplete = false;
@@ -408,15 +410,15 @@ export const mountDoorEntrance = (
   let disposed = false;
 
   const scene = new VanillaDoorScene(
-    options.className ?? activePreset.className ?? DEFAULT_CLASS_NAME
+    options.className ?? activeDoorVariant.className ?? DEFAULT_CLASS_NAME
   );
   target.append(scene.element);
 
   const audio = document.createElement("audio");
   let resolvedTextureUrl =
-    options.textureUrl ?? activePreset.textureUrl ?? DEFAULT_TEXTURE_URL;
+    options.textureUrl ?? activeDoorVariant.textureUrl ?? DEFAULT_TEXTURE_URL;
   let resolvedSoundUrl = toPublicAssetUrl(
-    options.soundUrl ?? activePreset.soundUrl ?? DEFAULT_SOUND_URL
+    options.soundUrl ?? activeDoorVariant.soundUrl ?? DEFAULT_SOUND_URL
   );
 
   if (resolvedSoundUrl) {
@@ -557,7 +559,7 @@ export const mountDoorEntrance = (
     const state = config.getState(easedProgress, {
       linearProgress: progress,
       handleProfileId:
-        options.handleProfileId ?? activePreset.handleProfileId ?? "lever-l",
+        activeDoorVariant.handleProfileId ?? "lever-l",
     });
     scene.render({
       state,
@@ -583,13 +585,15 @@ export const mountDoorEntrance = (
     }
   };
 
-  const resolvePreset = (nextPreset?: DoorEntrancePresetId) => {
-    activePreset = getDoorEntrancePreset(nextPreset ?? activePreset.id);
-    activeConfig = getDoorAnimationConfig(options.variant ?? activePreset.variant);
+  const resolveVariant = (nextVariant?: DoorEntranceVariantId) => {
+    activeDoorVariant = nextVariant
+      ? resolveDoorEntranceVariantSelection({ variant: nextVariant })
+      : activeDoorVariant;
+    activeConfig = getDoorAnimationConfig(activeDoorVariant.animation);
     resolvedTextureUrl =
-      options.textureUrl ?? activePreset.textureUrl ?? DEFAULT_TEXTURE_URL;
+      options.textureUrl ?? activeDoorVariant.textureUrl ?? DEFAULT_TEXTURE_URL;
     resolvedSoundUrl = toPublicAssetUrl(
-      options.soundUrl ?? activePreset.soundUrl ?? DEFAULT_SOUND_URL
+      options.soundUrl ?? activeDoorVariant.soundUrl ?? DEFAULT_SOUND_URL
     );
     if (resolvedSoundUrl && audio.src !== resolvedSoundUrl) {
       audio.src = resolvedSoundUrl;
@@ -637,10 +641,10 @@ export const mountDoorEntrance = (
   };
 
   const api: MountedDoorEntrance = {
-    play: (preset) => {
+    play: (variant) => {
       if (disposed || isAnimating) return;
 
-      const config = resolvePreset(preset);
+      const config = resolveVariant(variant);
       const startProgress = progress >= 1 ? 0 : progress;
       if (startProgress !== progress) {
         renderProgress(startProgress, config);
@@ -685,23 +689,23 @@ export const mountDoorEntrance = (
       pauseSound();
       emitSoundProgress();
     },
-    reset: (preset) => {
+    reset: (variant) => {
       if (disposed) return;
       cancelAnimationLoop();
       isAnimating = false;
       clearAudioDelayTimer();
       resetSound();
-      const config = resolvePreset(preset);
+      const config = resolveVariant(variant);
       didComplete = false;
       renderProgress(0, config);
     },
-    seek: (nextProgress, preset) => {
+    seek: (nextProgress, variant) => {
       if (disposed) return;
       cancelAnimationLoop();
       isAnimating = false;
       clearAudioDelayTimer();
       pauseSound();
-      const config = resolvePreset(preset);
+      const config = resolveVariant(variant);
       renderProgress(nextProgress, config);
       syncSoundToTimelineProgress(clampProgress(nextProgress), config);
     },

--- a/packages/door-lib/src/vanilla.ts
+++ b/packages/door-lib/src/vanilla.ts
@@ -6,10 +6,10 @@ import type {
   DoorAnimationConfig,
   DoorAnimationVariant,
   DoorEntranceMotion,
+  DoorEntrancePresetId,
   DoorEntranceSoundState,
   DoorEntranceType,
   DoorEntranceVariant,
-  DoorEntranceVariantId,
   DoorEntranceVariantSelection,
   DoorMaterialId,
   HandleProfileId,
@@ -33,10 +33,10 @@ interface MountDoorEntranceOptions extends DoorEntranceVariantSelection {
 }
 
 interface MountedDoorEntrance {
-  play: (variant?: DoorEntranceVariantId) => void;
+  play: (variant?: DoorEntrancePresetId) => void;
   stop: () => void;
-  reset: (variant?: DoorEntranceVariantId) => void;
-  seek: (progress: number, variant?: DoorEntranceVariantId) => void;
+  reset: (variant?: DoorEntrancePresetId) => void;
+  seek: (progress: number, variant?: DoorEntrancePresetId) => void;
   seekSound: (progress: number) => void;
   unmount: () => void;
 }
@@ -585,9 +585,9 @@ export const mountDoorEntrance = (
     }
   };
 
-  const resolveVariant = (nextVariant?: DoorEntranceVariantId) => {
+  const resolveVariant = (nextVariant?: DoorEntrancePresetId) => {
     activeDoorVariant = nextVariant
-      ? resolveDoorEntranceVariantSelection({ variant: nextVariant })
+      ? resolveDoorEntranceVariantSelection({ preset: nextVariant })
       : activeDoorVariant;
     activeConfig = getDoorAnimationConfig(activeDoorVariant.animation);
     resolvedTextureUrl =

--- a/packages/sample/public/samples/vanilla.html
+++ b/packages/sample/public/samples/vanilla.html
@@ -67,11 +67,11 @@
   <body>
     <div class="panel">
       <div class="toolbar">
-        <label for="door-preset">選擇 preset：</label>
-        <select id="door-preset">
-          <option value="door-single">door-single</option>
-          <option value="door-single-overhead">door-single-overhead</option>
-          <option value="door-double">door-double</option>
+        <label for="door-variant">選擇 variant：</label>
+        <select id="door-variant">
+          <option value="single-lever-wood">single-lever-wood</option>
+          <option value="single-overhead-lever-wood">single-overhead-lever-wood</option>
+          <option value="double-lever-wood">double-lever-wood</option>
         </select>
         <button id="door-play">播放</button>
         <span id="door-status">準備中...</span>

--- a/packages/sample/src/pages/Index.tsx
+++ b/packages/sample/src/pages/Index.tsx
@@ -2,14 +2,14 @@ import ReactSample from "@/sample/ReactSample";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { doorEntrancePresets } from "retro-horror-door";
+import { doorEntranceVariants } from "retro-horror-door";
 import { Link } from "react-router-dom";
 
 const reactSnippet = `import { DoorEntrance } from 'retro-horror-door/react';
 
 export const LandingGate = () => (
   <DoorEntrance
-    preset="door-single"
+    variant="single-lever-wood"
     onComplete={() => console.log('done')}
   />
 );`;
@@ -20,7 +20,7 @@ const htmlSnippet = `<div id="door-root"></div>
 
   mountDoorEntrance({
     target: document.getElementById('door-root'),
-    preset: 'door-single',
+    variant: 'single-lever-wood',
     autoPlay: true,
   });
 </script>`;
@@ -43,16 +43,16 @@ const Index = () => {
             門入場動畫 Library
           </h1>
           <p className="max-w-3xl text-lg text-white/70">
-            兩款動畫都抽成 module：direct-entry（正面開門推進）與
-            single-top-down-entry（俯視降落後開門）。預設入口提供 vanilla mount helper；React adapter 會放在獨立入口。
+            門動畫以可播放 variant 封裝；預設入口提供 vanilla mount
+            helper，React adapter 則放在獨立入口。
           </p>
           <div className="flex flex-wrap gap-2 text-sm text-white/60">
-            {doorEntrancePresets.map((preset) => (
+            {doorEntranceVariants.map((variant) => (
               <span
-                key={preset.id}
+                key={variant.id}
                 className="rounded-full border border-white/10 px-3 py-1"
               >
-                {preset.id}
+                {variant.id}
               </span>
             ))}
           </div>
@@ -129,7 +129,7 @@ const Index = () => {
             </CardHeader>
             <CardContent className="space-y-4">
               <p className="text-sm text-white/70">
-                導入 `DoorEntrance`，指定 preset（例如 `door-single`）。`onComplete` 會在動畫結束後觸發。
+                導入 `DoorEntrance`，指定 variant（例如 `single-lever-wood`）。`onComplete` 會在動畫結束後觸發。
               </p>
               <CodeBlock code={reactSnippet} />
             </CardContent>

--- a/packages/sample/src/sample/ReactSample.tsx
+++ b/packages/sample/src/sample/ReactSample.tsx
@@ -112,7 +112,8 @@ const loadWaveSurfer = (): Promise<WaveSurferFactory> => {
 };
 
 const ReactSample = () => {
-  const [preset, setPreset] = useState<DoorEntrancePresetId>("door-single");
+  const [preset, setPreset] =
+    useState<DoorEntrancePresetId>("single-lever-wood");
   const [status, setStatus] = useState("等待播放");
   const [ready, setReady] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -163,7 +164,7 @@ const ReactSample = () => {
     [selectedPresetMeta]
   );
   const config = useMemo(
-    () => getDoorAnimationConfig(getDoorEntrancePreset(preset).variant),
+    () => getDoorAnimationConfig(getDoorEntrancePreset(preset).animation),
     [preset]
   );
   const progressMarkers = config.progressMarkers;
@@ -549,7 +550,7 @@ const ReactSample = () => {
         >
           <DoorEntrance
             ref={ref}
-            preset={preset}
+            variant={preset}
             autoPlay={false}
             cameraPanX={cameraPanX}
             cameraPanY={cameraPanY}
@@ -719,7 +720,7 @@ const ReactSample = () => {
                     : audioReady
                       ? "等待 WaveSurfer 載入"
                       : "等待音檔 metadata"
-                : "Only door-single has sound"}
+                : "Only single-lever-wood has sound"}
             </span>
           </div>
         </div>

--- a/packages/sample/src/sample/vanillaEntry.ts
+++ b/packages/sample/src/sample/vanillaEntry.ts
@@ -1,5 +1,5 @@
 import "../index.css";
-import { mountDoorEntrance, type DoorEntrancePresetId } from "retro-horror-door";
+import { mountDoorEntrance, type DoorEntranceVariantId } from "retro-horror-door";
 
 type MountedDoorEntrance = ReturnType<typeof mountDoorEntrance>;
 type DoorEntranceTestApi = {
@@ -13,8 +13,8 @@ type DoorEntranceTestApi = {
 
 const target = document.getElementById("door-root");
 const statusEl = document.getElementById("door-status");
-const presetSelect = document.getElementById(
-  "door-preset"
+const variantSelect = document.getElementById(
+  "door-variant"
 ) as HTMLSelectElement | null;
 const playButton = document.getElementById("door-play");
 let ready = false;
@@ -35,15 +35,15 @@ const setStatus = (text: string) => {
 
 const boot = () => {
   if (!target) return;
-  const getSelectedPreset = (): DoorEntrancePresetId =>
-    (presetSelect?.value as DoorEntrancePresetId) ?? "door-single";
+  const getSelectedVariant = (): DoorEntranceVariantId =>
+    (variantSelect?.value as DoorEntranceVariantId) ?? "single-lever-wood";
 
-  const mountApp = (preset: DoorEntrancePresetId) => {
+  const mountApp = (variant: DoorEntranceVariantId) => {
     ready = false;
     animationProgress = 0;
     return mountDoorEntrance({
       target,
-      preset,
+      variant,
       autoPlay: false,
       className:
         "h-[420px] w-full rounded-xl border border-white/10 bg-black",
@@ -58,7 +58,7 @@ const boot = () => {
     });
   };
 
-  let app: MountedDoorEntrance | null = mountApp(getSelectedPreset());
+  let app: MountedDoorEntrance | null = mountApp(getSelectedVariant());
 
   const play = () => {
     if (!ready) {
@@ -66,21 +66,21 @@ const boot = () => {
       return;
     }
     setStatus("播放中...");
-    const preset = getSelectedPreset();
-    app?.reset(preset);
-    requestAnimationFrame(() => app?.play(preset));
+    const variant = getSelectedVariant();
+    app?.reset(variant);
+    requestAnimationFrame(() => app?.play(variant));
   };
 
   if (playButton) {
     playButton.addEventListener("click", play);
   }
 
-  if (presetSelect) {
-    presetSelect.addEventListener("change", (event) => {
-      const nextPreset = (event.target as HTMLSelectElement)
-        .value as DoorEntrancePresetId;
+  if (variantSelect) {
+    variantSelect.addEventListener("change", (event) => {
+      const nextVariant = (event.target as HTMLSelectElement)
+        .value as DoorEntranceVariantId;
       app?.unmount();
-      app = mountApp(nextPreset);
+      app = mountApp(nextVariant);
       setStatus("準備中...");
     });
   }
@@ -88,8 +88,8 @@ const boot = () => {
   if (testMode) {
     window.__doorEntranceTestApi__ = {
       play,
-      reset: () => app?.reset(getSelectedPreset()),
-      seek: (progress) => app?.seek(progress, getSelectedPreset()),
+      reset: () => app?.reset(getSelectedVariant()),
+      seek: (progress) => app?.seek(progress, getSelectedVariant()),
       unmount: () => {
         app?.unmount();
         app = null;


### PR DESCRIPTION
## Summary

- Introduce concrete door `variant` IDs such as `single-lever-wood` for the public selection API.
- Add a runtime variant registry and random selection that only chooses from existing playable variants.
- Keep deprecated `preset` compatibility aliases while making `variant` strict and rejecting unknown values.
- Update vanilla sample, React adapter, README, architecture docs, and Notion-facing implementation language around variants.

## Validation

- `npm run test:lib:core`
- `npm run lint --workspace retro-horror-door`
- `npm run verify:lib:boundary`
- `npm run build --workspace retro-horror-door-sample`
- `npm run lint --workspace retro-horror-door-sample` (0 errors, existing Fast Refresh warnings)
- `npm run verify:lib:browser`

## Notes

- Runtime variant entries intentionally do not include source videos, thumbnails, `sourceRefs`, or classification notes.
- `preset` remains deprecated compatibility surface; new docs and samples use `variant`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added door entrance variants with support for direct selection, random selection, and filtering by type, motion, handle, or material.
  * Exposed variant lookup and selection APIs.
  * Updated controls and samples to use variant identifiers.

* **Bug Fixes**
  * Unknown or conflicting selections now produce clear errors instead of silently falling back.

* **Documentation**
  * Updated usage examples and architecture documentation to describe variants and legacy compatibility.

* **Chores**
  * Excluded test result artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->