### PR TITLE
feat: support per-surface door textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Plain HTML:
 ```
 
 Runtime variant entries contain only playable library settings such as type,
-motion, handle, material, sound, and camera behavior. Source videos,
+motion, handle, material, sound, and camera behavior. A variant can also
+provide `frontTextureUrl`, `edgeTextureUrl`, and `backTextureUrl`: when edge
+or back is absent it inherits the front texture. The legacy `textureUrl`
+field remains supported and applies the same texture to all three surfaces.
+Source videos,
 classification notes, and thumbnail references belong in development tracking
 docs and are not shipped in the npm package.

--- a/packages/door-lib/docs/ARCHITECTURE.md
+++ b/packages/door-lib/docs/ARCHITECTURE.md
@@ -66,6 +66,7 @@ export interface DoorAnimationConfig {
 - 目標契約：`DoorEntrance` 與 React-free `vanilla` renderer 應只依賴這層，適合時間軸驅動的開門動畫。
 - 目前狀態：`retro-horror-door` 預設匯出 DOM + Three.js 的 vanilla renderer；`retro-horror-door/vanilla` 保留為相容別名。兩者都不透過 React、React DOM 或 R3F 掛載；React support 應留在 `retro-horror-door/react` adapter surface。
 - 公開選門 API 使用 `variant`，例如 `single-lever-wood`。`variant` 是一個可播放門變體，內部固定 `type`、`motion`、`handleProfileId`、`material`、animation config、聲音與鏡頭行為。
+- 每個 runtime variant 可指定 `frontTextureUrl`、`edgeTextureUrl`、`backTextureUrl`。未指定側邊或背面時，renderer 會使用正面貼圖；`textureUrl` 僅保留給舊版相容，等同三個面皆使用同一張圖。這些欄位屬於 variant，不提供新的 per-mount 客製欄位。
 - `random: true` 只從可用 runtime variants 中挑選；`type`、`motion`、`handle`、`material` 只在 random mode 作為篩選條件。有明確 `variant` 時不能再混用這些欄位。
 - Runtime variant registry 不包含來源影片、縮圖或分類筆記。這些只存在於 Notion / gallery / dev tracking metadata，不能進 npm package。
 

--- a/packages/door-lib/src/core/__tests__/variants.test.ts
+++ b/packages/door-lib/src/core/__tests__/variants.test.ts
@@ -5,6 +5,7 @@ import {
   getDoorEntranceVariant,
   resolveDoorEntranceVariantSelection,
 } from "../variants.ts";
+import { resolveDoorSurfaceTextureUrls } from "../surfaceTextures.ts";
 
 describe("core door entrance variants", () => {
   it("returns a complete playable variant by id", () => {
@@ -23,6 +24,35 @@ describe("core door entrance variants", () => {
       assert.equal("sourceRefs" in variant, false);
       assert.equal("thumbnailRefs" in variant, false);
     }
+  });
+
+  it("resolves missing back and edge textures from the front texture", () => {
+    const textures = resolveDoorSurfaceTextureUrls(
+      {
+        frontTextureUrl: "/textures/door-front.png",
+        edgeTextureUrl: "/textures/door-edge.png",
+      },
+      "/textures/default-door.png"
+    );
+
+    assert.deepEqual(textures, {
+      frontTextureUrl: "/textures/door-front.png",
+      edgeTextureUrl: "/textures/door-edge.png",
+      backTextureUrl: "/textures/door-front.png",
+    });
+  });
+
+  it("keeps the legacy texture URL as the fallback for every door surface", () => {
+    const textures = resolveDoorSurfaceTextureUrls(
+      { textureUrl: "/textures/legacy-door.png" },
+      "/textures/default-door.png"
+    );
+
+    assert.deepEqual(textures, {
+      frontTextureUrl: "/textures/legacy-door.png",
+      edgeTextureUrl: "/textures/legacy-door.png",
+      backTextureUrl: "/textures/legacy-door.png",
+    });
   });
 
   it("resolves random selection from variants matching the requested type", () => {

--- a/packages/door-lib/src/core/surfaceTextures.ts
+++ b/packages/door-lib/src/core/surfaceTextures.ts
@@ -1,0 +1,18 @@
+import type {
+  DoorSurfaceTextureUrls,
+  ResolvedDoorSurfaceTextureUrls,
+} from "./types.ts";
+
+export const resolveDoorSurfaceTextureUrls = (
+  textures: DoorSurfaceTextureUrls,
+  defaultTextureUrl: string
+): ResolvedDoorSurfaceTextureUrls => {
+  const frontTextureUrl =
+    textures.frontTextureUrl ?? textures.textureUrl ?? defaultTextureUrl;
+
+  return {
+    frontTextureUrl,
+    edgeTextureUrl: textures.edgeTextureUrl ?? frontTextureUrl,
+    backTextureUrl: textures.backTextureUrl ?? frontTextureUrl,
+  };
+};

--- a/packages/door-lib/src/core/types.ts
+++ b/packages/door-lib/src/core/types.ts
@@ -26,7 +26,21 @@ export type LegacyDoorEntrancePresetId =
   | "door-single-overhead"
   | "door-double";
 
-export interface DoorEntranceVariant {
+export interface DoorSurfaceTextureUrls {
+  frontTextureUrl?: string;
+  edgeTextureUrl?: string;
+  backTextureUrl?: string;
+  /** @deprecated Use frontTextureUrl, edgeTextureUrl, and backTextureUrl. */
+  textureUrl?: string;
+}
+
+export interface ResolvedDoorSurfaceTextureUrls {
+  frontTextureUrl: string;
+  edgeTextureUrl: string;
+  backTextureUrl: string;
+}
+
+export interface DoorEntranceVariant extends DoorSurfaceTextureUrls {
   id: DoorEntranceVariantId;
   label: string;
   type: DoorEntranceType;
@@ -35,7 +49,6 @@ export interface DoorEntranceVariant {
   animation: DoorAnimationVariant;
   /** @deprecated Use animation. Kept for preset compatibility only. */
   variant: DoorAnimationVariant;
-  textureUrl?: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
   soundUrl?: string;

--- a/packages/door-lib/src/index.ts
+++ b/packages/door-lib/src/index.ts
@@ -21,6 +21,7 @@ export {
   getDoorEntranceVariant,
   resolveDoorEntranceVariantSelection,
 } from "./core/variants.ts";
+export { resolveDoorSurfaceTextureUrls } from "./core/surfaceTextures.ts";
 export type {
   DoorAnimationConfig,
   DoorAnimationState,
@@ -33,6 +34,8 @@ export type {
   DoorEntranceVariantId,
   DoorEntranceVariantSelection,
   DoorEntranceSoundState,
+  DoorSurfaceTextureUrls,
+  ResolvedDoorSurfaceTextureUrls,
   DoorMaterialId,
   HandleProfileId,
   Vector3Tuple,

--- a/packages/door-lib/src/module/DoorEntrance.tsx
+++ b/packages/door-lib/src/module/DoorEntrance.tsx
@@ -27,6 +27,7 @@ import {
 } from "./types";
 import { getHandleProfile } from "./handles/profiles";
 import { doorWood } from "../assets/textures";
+import { resolveDoorSurfaceTextureUrls } from "../core/surfaceTextures.ts";
 
 interface DoorEntranceProps {
   /** @deprecated Use variant. */
@@ -104,7 +105,9 @@ const CameraController = ({
 
 const Scene = ({
   state,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
   cameraPanX,
@@ -112,7 +115,9 @@ const Scene = ({
   Renderer,
 }: {
   state: DoorAnimationState;
-  textureUrl: string;
+  frontTextureUrl: string;
+  edgeTextureUrl: string;
+  backTextureUrl: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
   cameraPanX: number;
@@ -126,7 +131,9 @@ const Scene = ({
     <pointLight position={[0, 2, 3]} intensity={0.5} color="#ff8844" />
     <Renderer
       state={state}
-      textureUrl={textureUrl}
+      frontTextureUrl={frontTextureUrl}
+      edgeTextureUrl={edgeTextureUrl}
+      backTextureUrl={backTextureUrl}
       handleModelUrl={handleModelUrl}
       handleProfileId={handleProfileId}
     />
@@ -172,8 +179,13 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
       [activePreset]
     );
     const resolvedAnimation = selectedPreset.animation;
-    const resolvedTextureUrl =
-      textureUrl ?? selectedPreset.textureUrl ?? DEFAULT_TEXTURE_URL;
+    const resolvedSurfaceTextureUrls = textureUrl
+      ? {
+          frontTextureUrl: textureUrl,
+          edgeTextureUrl: textureUrl,
+          backTextureUrl: textureUrl,
+        }
+      : resolveDoorSurfaceTextureUrls(selectedPreset, DEFAULT_TEXTURE_URL);
     const resolvedHandleProfileId =
       handleProfileId ?? selectedPreset.handleProfileId ?? "lever-l";
     const resolvedHandleProfile = getHandleProfile(resolvedHandleProfileId);
@@ -197,7 +209,9 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
         state: _state,
       }: {
         state: DoorAnimationState;
-        textureUrl: string;
+        frontTextureUrl: string;
+        edgeTextureUrl: string;
+        backTextureUrl: string;
       }) => (
         <mesh position={[0, 0, 0]}>
           <boxGeometry args={[3, 6, 0.15]} />
@@ -670,7 +684,9 @@ const DoorEntrance = forwardRef<DoorEntranceHandle, DoorEntranceProps>(
         >
           <Scene
             state={state}
-            textureUrl={resolvedTextureUrl}
+            frontTextureUrl={resolvedSurfaceTextureUrls.frontTextureUrl}
+            edgeTextureUrl={resolvedSurfaceTextureUrls.edgeTextureUrl}
+            backTextureUrl={resolvedSurfaceTextureUrls.backTextureUrl}
             handleModelUrl={resolvedHandleModelUrl}
             handleProfileId={resolvedHandleProfileId}
             cameraPanX={cameraPanX}

--- a/packages/door-lib/src/module/animations/direct-entry/index.tsx
+++ b/packages/door-lib/src/module/animations/direct-entry/index.tsx
@@ -17,31 +17,36 @@ export const directEntryConfig: DoorAnimationConfig = coreDirectEntryConfig;
 const SingleDoor = ({
   doorAngle,
   handleAngle,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
 }: {
   doorAngle: number;
   handleAngle: number;
-  textureUrl: string;
+  frontTextureUrl: string;
+  edgeTextureUrl: string;
+  backTextureUrl: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
 }) => {
   const doorGroupRef = useRef<any>(null);
-  const doorTexture = (useLoader as unknown as any)(
+  const [frontTexture, edgeTexture, backTexture] = (useLoader as unknown as any)(
     THREE.TextureLoader,
-    textureUrl,
-  ) as any;
+    [frontTextureUrl, edgeTextureUrl, backTextureUrl],
+  ) as any[];
 
   useEffect(() => {
-    if (doorTexture) {
-      doorTexture.wrapS = doorTexture.wrapT = THREE.ClampToEdgeWrapping;
-      doorTexture.repeat.set(1, 1);
-      doorTexture.offset.set(0, 0);
-      doorTexture.flipY = false;
-      doorTexture.needsUpdate = true;
-    }
-  }, [doorTexture]);
+    [frontTexture, edgeTexture, backTexture].forEach((texture) => {
+      if (!texture) return;
+      texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+      texture.repeat.set(1, 1);
+      texture.offset.set(0, 0);
+      texture.flipY = false;
+      texture.needsUpdate = true;
+    });
+  }, [backTexture, edgeTexture, frontTexture]);
 
   useFrame(() => {
     if (doorGroupRef.current) {
@@ -64,16 +69,16 @@ const SingleDoor = ({
       <group ref={doorGroupRef} position={[-1.5, 0, 0]}>
         <mesh position={[1.5, 0, 0.08]}>
           <boxGeometry args={[3, 6, 0.15]} />
-          <meshLambertMaterial color="#8B4513" />
+          <meshLambertMaterial map={edgeTexture} />
         </mesh>
 
         <mesh position={[1.5, 0, 0.16]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={frontTexture} />
         </mesh>
         <mesh position={[1.5, 0, 0]} rotation={[0, Math.PI, 0]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={backTexture} />
         </mesh>
 
         {handleModelUrl ? (
@@ -96,7 +101,9 @@ const SingleDoor = ({
 
 export const DirectEntryRenderer: DoorAnimationRenderer = ({
   state,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
 }) => {
@@ -104,7 +111,9 @@ export const DirectEntryRenderer: DoorAnimationRenderer = ({
     <SingleDoor
       doorAngle={state.doorAngle}
       handleAngle={state.handleAngle ?? 0}
-      textureUrl={textureUrl}
+      frontTextureUrl={frontTextureUrl}
+      edgeTextureUrl={edgeTextureUrl}
+      backTextureUrl={backTextureUrl}
       handleModelUrl={handleModelUrl}
       handleProfileId={handleProfileId}
     />

--- a/packages/door-lib/src/module/animations/double-swing/index.tsx
+++ b/packages/door-lib/src/module/animations/double-swing/index.tsx
@@ -20,33 +20,38 @@ const DoubleDoor = ({
   leftAngle,
   rightAngle,
   handleAngle,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
 }: {
   leftAngle: number;
   rightAngle: number;
   handleAngle: number;
-  textureUrl: string;
+  frontTextureUrl: string;
+  edgeTextureUrl: string;
+  backTextureUrl: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
 }) => {
   const leftRef = useRef<any>(null);
   const rightRef = useRef<any>(null);
-  const doorTexture = (useLoader as unknown as any)(
+  const [frontTexture, edgeTexture, backTexture] = (useLoader as unknown as any)(
     THREE.TextureLoader,
-    textureUrl,
-  ) as any;
+    [frontTextureUrl, edgeTextureUrl, backTextureUrl],
+  ) as any[];
 
   useEffect(() => {
-    if (doorTexture) {
-      doorTexture.wrapS = doorTexture.wrapT = THREE.ClampToEdgeWrapping;
-      doorTexture.repeat.set(1, 1);
-      doorTexture.offset.set(0, 0);
-      doorTexture.flipY = false;
-      doorTexture.needsUpdate = true;
-    }
-  }, [doorTexture]);
+    [frontTexture, edgeTexture, backTexture].forEach((texture) => {
+      if (!texture) return;
+      texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+      texture.repeat.set(1, 1);
+      texture.offset.set(0, 0);
+      texture.flipY = false;
+      texture.needsUpdate = true;
+    });
+  }, [backTexture, edgeTexture, frontTexture]);
 
   useFrame(() => {
     if (leftRef.current) {
@@ -73,15 +78,15 @@ const DoubleDoor = ({
       <group ref={leftRef} position={[-3, 0, 0]}>
         <mesh position={[1.5, 0, 0.08]}>
           <boxGeometry args={[3, 6, 0.15]} />
-          <meshLambertMaterial color="#8B4513" />
+          <meshLambertMaterial map={edgeTexture} />
         </mesh>
         <mesh position={[1.5, 0, 0.16]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={frontTexture} />
         </mesh>
         <mesh position={[1.5, 0, 0]} rotation={[0, Math.PI, 0]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={backTexture} />
         </mesh>
         {handleModelUrl ? (
           <DoorHandleModel
@@ -102,15 +107,15 @@ const DoubleDoor = ({
       <group ref={rightRef} position={[3, 0, 0]}>
         <mesh position={[-1.5, 0, 0.08]}>
           <boxGeometry args={[3, 6, 0.15]} />
-          <meshLambertMaterial color="#8B4513" />
+          <meshLambertMaterial map={edgeTexture} />
         </mesh>
         <mesh position={[-1.5, 0, 0.16]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={frontTexture} />
         </mesh>
         <mesh position={[-1.5, 0, 0]} rotation={[0, Math.PI, 0]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={backTexture} />
         </mesh>
         {handleModelUrl ? (
           <DoorHandleModel
@@ -133,7 +138,9 @@ const DoubleDoor = ({
 
 export const DoubleSwingRenderer: DoorAnimationRenderer = ({
   state,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
 }) => {
@@ -142,7 +149,9 @@ export const DoubleSwingRenderer: DoorAnimationRenderer = ({
       leftAngle={state.doorAngle}
       rightAngle={state.rightDoorAngle ?? state.doorAngle}
       handleAngle={state.handleAngle ?? 0}
-      textureUrl={textureUrl}
+      frontTextureUrl={frontTextureUrl}
+      edgeTextureUrl={edgeTextureUrl}
+      backTextureUrl={backTextureUrl}
       handleModelUrl={handleModelUrl}
       handleProfileId={handleProfileId}
     />

--- a/packages/door-lib/src/module/animations/top-down-entry/index.tsx
+++ b/packages/door-lib/src/module/animations/top-down-entry/index.tsx
@@ -18,31 +18,36 @@ export const singleTopDownConfig: DoorAnimationConfig =
 const SingleDoor = ({
   doorAngle,
   handleAngle,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
 }: {
   doorAngle: number;
   handleAngle: number;
-  textureUrl: string;
+  frontTextureUrl: string;
+  edgeTextureUrl: string;
+  backTextureUrl: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
 }) => {
   const doorGroupRef = useRef<any>(null);
-  const doorTexture = (useLoader as unknown as any)(
+  const [frontTexture, edgeTexture, backTexture] = (useLoader as unknown as any)(
     THREE.TextureLoader,
-    textureUrl,
-  ) as any;
+    [frontTextureUrl, edgeTextureUrl, backTextureUrl],
+  ) as any[];
 
   useEffect(() => {
-    if (doorTexture) {
-      doorTexture.wrapS = doorTexture.wrapT = THREE.ClampToEdgeWrapping;
-      doorTexture.repeat.set(1, 1);
-      doorTexture.offset.set(0, 0);
-      doorTexture.flipY = false;
-      doorTexture.needsUpdate = true;
-    }
-  }, [doorTexture]);
+    [frontTexture, edgeTexture, backTexture].forEach((texture) => {
+      if (!texture) return;
+      texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+      texture.repeat.set(1, 1);
+      texture.offset.set(0, 0);
+      texture.flipY = false;
+      texture.needsUpdate = true;
+    });
+  }, [backTexture, edgeTexture, frontTexture]);
 
   useFrame(() => {
     if (doorGroupRef.current) {
@@ -65,16 +70,16 @@ const SingleDoor = ({
       <group ref={doorGroupRef} position={[-1.5, 0, 0]}>
         <mesh position={[1.5, 0, 0.08]}>
           <boxGeometry args={[3, 6, 0.15]} />
-          <meshLambertMaterial color="#8B4513" />
+          <meshLambertMaterial map={edgeTexture} />
         </mesh>
 
         <mesh position={[1.5, 0, 0.16]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={frontTexture} />
         </mesh>
         <mesh position={[1.5, 0, 0]} rotation={[0, Math.PI, 0]}>
           <planeGeometry args={[3, 6]} />
-          <meshLambertMaterial map={doorTexture} />
+          <meshLambertMaterial map={backTexture} />
         </mesh>
 
         {handleModelUrl ? (
@@ -97,7 +102,9 @@ const SingleDoor = ({
 
 export const SingleTopDownEntryRenderer: DoorAnimationRenderer = ({
   state,
-  textureUrl,
+  frontTextureUrl,
+  edgeTextureUrl,
+  backTextureUrl,
   handleModelUrl,
   handleProfileId,
 }) => {
@@ -105,7 +112,9 @@ export const SingleTopDownEntryRenderer: DoorAnimationRenderer = ({
     <SingleDoor
       doorAngle={state.doorAngle}
       handleAngle={state.handleAngle ?? 0}
-      textureUrl={textureUrl}
+      frontTextureUrl={frontTextureUrl}
+      edgeTextureUrl={edgeTextureUrl}
+      backTextureUrl={backTextureUrl}
       handleModelUrl={handleModelUrl}
       handleProfileId={handleProfileId}
     />

--- a/packages/door-lib/src/module/index.ts
+++ b/packages/door-lib/src/module/index.ts
@@ -10,6 +10,7 @@ export type {
   DoorEntranceVariant,
   DoorEntranceVariantId,
   DoorEntranceSoundState,
+  DoorSurfaceTextureUrls,
   DoorMaterialId,
   HandleProfileId,
 } from "./types";

--- a/packages/door-lib/src/module/presets.ts
+++ b/packages/door-lib/src/module/presets.ts
@@ -12,6 +12,7 @@ import {
   legacyDoorEntrancePresetAliasMap,
   resolveDoorEntrancePresetId,
 } from "../core/variants.ts";
+import { resolveDoorSurfaceTextureUrls } from "../core/surfaceTextures.ts";
 import { doorWood } from "../assets/textures";
 import { doorOpenClose } from "../assets/sounds";
 
@@ -29,7 +30,9 @@ const doorEntranceVariantPresetMap: Record<
     preset.id,
     {
       ...preset,
-      textureUrl: preset.textureUrl ?? DEFAULT_DOOR_TEXTURE,
+      ...resolveDoorSurfaceTextureUrls(preset, DEFAULT_DOOR_TEXTURE),
+      textureUrl:
+        preset.frontTextureUrl ?? preset.textureUrl ?? DEFAULT_DOOR_TEXTURE,
       handleModelUrl: preset.handleModelUrl ?? DEFAULT_HANDLE_MODEL,
       handleProfileId: preset.handleProfileId ?? DEFAULT_HANDLE_PROFILE_ID,
       soundUrl: preset.soundUrl ?? DEFAULT_SINGLE_DOOR_SOUND,

--- a/packages/door-lib/src/module/types.ts
+++ b/packages/door-lib/src/module/types.ts
@@ -27,7 +27,15 @@ export type LegacyDoorEntrancePresetId =
   | "door-single-overhead"
   | "door-double";
 
-export interface DoorEntranceVariant {
+export interface DoorSurfaceTextureUrls {
+  frontTextureUrl?: string;
+  edgeTextureUrl?: string;
+  backTextureUrl?: string;
+  /** @deprecated Use frontTextureUrl, edgeTextureUrl, and backTextureUrl. */
+  textureUrl?: string;
+}
+
+export interface DoorEntranceVariant extends DoorSurfaceTextureUrls {
   id: DoorEntranceVariantId;
   label: string;
   type: DoorEntranceType;
@@ -36,7 +44,6 @@ export interface DoorEntranceVariant {
   animation: DoorAnimationVariant;
   /** @deprecated Use animation. Kept for preset compatibility only. */
   variant: DoorAnimationVariant;
-  textureUrl?: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
   soundUrl?: string;
@@ -60,7 +67,9 @@ export interface DoorAnimationState {
 
 export type DoorAnimationRenderer = (props: {
   state: DoorAnimationState;
-  textureUrl: string;
+  frontTextureUrl: string;
+  edgeTextureUrl: string;
+  backTextureUrl: string;
   handleModelUrl?: string;
   handleProfileId?: HandleProfileId;
 }) => JSX.Element;

--- a/packages/door-lib/src/vanilla.ts
+++ b/packages/door-lib/src/vanilla.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { getDoorAnimationConfig } from "./core/animationState.ts";
 import { resolveDoorEntranceVariantSelection } from "./core/variants.ts";
+import { resolveDoorSurfaceTextureUrls } from "./core/surfaceTextures.ts";
 import type {
   DoorAnimationState,
   DoorAnimationConfig,
@@ -13,6 +14,7 @@ import type {
   DoorEntranceVariantSelection,
   DoorMaterialId,
   HandleProfileId,
+  ResolvedDoorSurfaceTextureUrls,
 } from "./core/types.ts";
 import { doorWood } from "./assets/textures";
 import { doorOpenClose } from "./assets/sounds";
@@ -92,6 +94,16 @@ const createDoorMaterial = () =>
     metalness: 0.12,
   });
 
+const createDoorMaterials = () =>
+  Array.from({ length: 6 }, () => createDoorMaterial()) as [
+    THREE.MeshStandardMaterial,
+    THREE.MeshStandardMaterial,
+    THREE.MeshStandardMaterial,
+    THREE.MeshStandardMaterial,
+    THREE.MeshStandardMaterial,
+    THREE.MeshStandardMaterial,
+  ];
+
 const createHandleMaterial = () =>
   new THREE.MeshStandardMaterial({
     color: "#74685c",
@@ -110,10 +122,10 @@ class VanillaDoorScene {
   private readonly label = document.createElement("div");
   private readonly resizeObserver?: ResizeObserver;
   private doorRoot = new THREE.Group();
-  private activeTextureUrl?: string;
+  private activeSurfaceTextureKey?: string;
   private activeVariant?: DoorAnimationVariant;
   private activeHandleGroup?: THREE.Group;
-  private baseDoorMaterial = createDoorMaterial();
+  private doorMaterials = createDoorMaterials();
   private handleMaterial = createHandleMaterial();
 
   constructor(className: string) {
@@ -171,23 +183,32 @@ class VanillaDoorScene {
   render({
     state,
     config,
-    textureUrl,
+    surfaceTextureUrls,
     cameraPanX,
     cameraPanY,
   }: {
     state: DoorAnimationState;
     config: DoorAnimationConfig;
-    textureUrl: string;
+    surfaceTextureUrls: ResolvedDoorSurfaceTextureUrls;
     cameraPanX: number;
     cameraPanY: number;
   }) {
     if (
       this.activeVariant !== config.id ||
-      this.activeTextureUrl !== textureUrl
+      this.activeSurfaceTextureKey !==
+        [
+          surfaceTextureUrls.frontTextureUrl,
+          surfaceTextureUrls.edgeTextureUrl,
+          surfaceTextureUrls.backTextureUrl,
+        ].join("|")
     ) {
-      this.rebuildDoor(config.id, textureUrl);
+      this.rebuildDoor(config.id, surfaceTextureUrls);
       this.activeVariant = config.id;
-      this.activeTextureUrl = textureUrl;
+      this.activeSurfaceTextureKey = [
+        surfaceTextureUrls.frontTextureUrl,
+        surfaceTextureUrls.edgeTextureUrl,
+        surfaceTextureUrls.backTextureUrl,
+      ].join("|");
     }
 
     this.applyDoorState(config.id, state);
@@ -202,7 +223,7 @@ class VanillaDoorScene {
     this.resizeObserver?.disconnect();
     disposeObject(this.doorRoot);
     this.scene.remove(this.doorRoot);
-    this.baseDoorMaterial.dispose();
+    this.doorMaterials.forEach((material) => material.dispose());
     this.handleMaterial.dispose();
     this.renderer.dispose();
     this.element.remove();
@@ -224,21 +245,22 @@ class VanillaDoorScene {
     }
   }
 
-  private rebuildDoor(variant: DoorAnimationVariant, textureUrl: string) {
+  private rebuildDoor(
+    variant: DoorAnimationVariant,
+    surfaceTextureUrls: ResolvedDoorSurfaceTextureUrls
+  ) {
     disposeObject(this.doorRoot);
     this.scene.remove(this.doorRoot);
     this.doorRoot = new THREE.Group();
     this.scene.add(this.doorRoot);
     this.activeHandleGroup = undefined;
 
-    this.baseDoorMaterial = createDoorMaterial();
+    this.doorMaterials = createDoorMaterials();
     this.handleMaterial = createHandleMaterial();
-    this.textureLoader.load(textureUrl, (texture) => {
-      texture.wrapS = THREE.RepeatWrapping;
-      texture.wrapT = THREE.RepeatWrapping;
-      this.baseDoorMaterial.map = texture;
-      this.baseDoorMaterial.needsUpdate = true;
-    });
+    const doorMaterials = this.doorMaterials;
+    this.loadTexture(surfaceTextureUrls.frontTextureUrl, [4], doorMaterials);
+    this.loadTexture(surfaceTextureUrls.edgeTextureUrl, [0, 1, 2, 3], doorMaterials);
+    this.loadTexture(surfaceTextureUrls.backTextureUrl, [5], doorMaterials);
 
     this.addFrame();
 
@@ -273,6 +295,22 @@ class VanillaDoorScene {
     });
     single.name = "single-door";
     this.doorRoot.add(single);
+  }
+
+  private loadTexture(
+    url: string,
+    materialIndexes: number[],
+    materials: typeof this.doorMaterials
+  ) {
+    this.textureLoader.load(url, (texture) => {
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      materialIndexes.forEach((index) => {
+        const material = materials[index];
+        material.map = texture;
+        material.needsUpdate = true;
+      });
+    });
   }
 
   private addFrame() {
@@ -315,7 +353,7 @@ class VanillaDoorScene {
 
     const door = new THREE.Mesh(
       new THREE.BoxGeometry(width, height, 0.16),
-      this.baseDoorMaterial
+      this.doorMaterials
     );
     const doorOffset = side === "right" ? width / 2 : -pivotX + width / 2 - 1.5;
     door.position.set(side === "left" ? -width / 2 : doorOffset, 0, 0);
@@ -415,8 +453,13 @@ export const mountDoorEntrance = (
   target.append(scene.element);
 
   const audio = document.createElement("audio");
-  let resolvedTextureUrl =
-    options.textureUrl ?? activeDoorVariant.textureUrl ?? DEFAULT_TEXTURE_URL;
+  let resolvedSurfaceTextureUrls = options.textureUrl
+    ? {
+        frontTextureUrl: options.textureUrl,
+        edgeTextureUrl: options.textureUrl,
+        backTextureUrl: options.textureUrl,
+      }
+    : resolveDoorSurfaceTextureUrls(activeDoorVariant, DEFAULT_TEXTURE_URL);
   let resolvedSoundUrl = toPublicAssetUrl(
     options.soundUrl ?? activeDoorVariant.soundUrl ?? DEFAULT_SOUND_URL
   );
@@ -564,7 +607,7 @@ export const mountDoorEntrance = (
     scene.render({
       state,
       config,
-      textureUrl: resolvedTextureUrl,
+      surfaceTextureUrls: resolvedSurfaceTextureUrls,
       cameraPanX: options.cameraPanX ?? 0,
       cameraPanY: options.cameraPanY ?? 0,
     });
@@ -590,8 +633,13 @@ export const mountDoorEntrance = (
       ? resolveDoorEntranceVariantSelection({ preset: nextVariant })
       : activeDoorVariant;
     activeConfig = getDoorAnimationConfig(activeDoorVariant.animation);
-    resolvedTextureUrl =
-      options.textureUrl ?? activeDoorVariant.textureUrl ?? DEFAULT_TEXTURE_URL;
+    resolvedSurfaceTextureUrls = options.textureUrl
+      ? {
+          frontTextureUrl: options.textureUrl,
+          edgeTextureUrl: options.textureUrl,
+          backTextureUrl: options.textureUrl,
+        }
+      : resolveDoorSurfaceTextureUrls(activeDoorVariant, DEFAULT_TEXTURE_URL);
     resolvedSoundUrl = toPublicAssetUrl(
       options.soundUrl ?? activeDoorVariant.soundUrl ?? DEFAULT_SOUND_URL
     );


### PR DESCRIPTION
## Summary
- add front, edge, and back texture URLs to runtime variants
- make vanilla and React renderers apply the resolved texture to each surface
- retain legacy textureUrl behavior and document the fallback rules

## Validation
- npm run verify:lib:core
- npm run test:lib:package
- npm run test:lib:browser