### PR TITLE
feat: add interactive preset catalog

### DIFF
--- a/packages/door-lib/src/__tests__/package-boundary.test.ts
+++ b/packages/door-lib/src/__tests__/package-boundary.test.ts
@@ -224,6 +224,24 @@ describe("package boundary", () => {
     assert.doesNotMatch(declaration, /getDoorEntranceVariant/);
   });
 
+  it("keeps the vanilla renderer limited to the door and its handle", () => {
+    const source = readFileSync(join(packageRoot, "src", "vanilla.ts"), "utf8");
+
+    assert.doesNotMatch(source, /addFrame/);
+    assert.doesNotMatch(source, /new THREE\.BoxGeometry\(5\.2, 0\.08, 4\)/);
+  });
+
+  it("keeps vanilla hinge geometry aligned with the original door behavior", () => {
+    const source = readFileSync(join(packageRoot, "src", "vanilla.ts"), "utf8");
+
+    assert.match(source, /width: 3,\s+height: 6,\s+pivotX: -1\.5/);
+    assert.match(source, /width: 3,\s+height: 6,\s+pivotX: -3/);
+    assert.match(source, /width: 3,\s+height: 6,\s+pivotX: 3/);
+    assert.match(source, /const maxAngle = Math\.PI \/ 2/);
+    assert.match(source, /new THREE\.PlaneGeometry\(width, height\)/);
+    assert.doesNotMatch(source, /width: 1\.48/);
+  });
+
   it("keeps the full vanilla output graph React-free", () => {
     assertOutputGraphReactFree({
       label: "vanilla",

--- a/packages/door-lib/src/core/presets.ts
+++ b/packages/door-lib/src/core/presets.ts
@@ -3,6 +3,7 @@ import type {
   DoorEntrancePresetId,
   DoorEntrancePresetSelection,
 } from "./types.ts";
+import { doorWood } from "../assets/textures";
 
 const DEFAULT_PRESET_ID: DoorEntrancePresetId = "single-lever-wood";
 
@@ -16,6 +17,7 @@ export const doorEntrancePresetMap: Record<
     type: "single",
     motion: "hinge-single",
     material: "wood-panel-aged",
+    frontTextureUrl: doorWood,
     animation: "direct-entry",
     handleProfileId: "lever-l",
   },
@@ -25,6 +27,7 @@ export const doorEntrancePresetMap: Record<
     type: "single",
     motion: "hinge-single-overhead",
     material: "wood-panel-aged",
+    frontTextureUrl: doorWood,
     animation: "single-top-down-entry",
     handleProfileId: "lever-l",
   },
@@ -34,6 +37,7 @@ export const doorEntrancePresetMap: Record<
     type: "double",
     motion: "hinge-double",
     material: "wood-panel-aged",
+    frontTextureUrl: doorWood,
     animation: "double-swing",
     handleProfileId: "lever-l",
   },

--- a/packages/door-lib/src/vanilla.ts
+++ b/packages/door-lib/src/vanilla.ts
@@ -104,6 +104,13 @@ const createDoorMaterials = () =>
     THREE.MeshStandardMaterial,
   ];
 
+const createDoorFaceMaterial = () =>
+  new THREE.MeshStandardMaterial({
+    color: "#ffffff",
+    roughness: 0.7,
+    metalness: 0.12,
+  });
+
 const createHandleMaterial = () =>
   new THREE.MeshStandardMaterial({
     color: "#74685c",
@@ -124,9 +131,15 @@ class VanillaDoorScene {
   private doorRoot = new THREE.Group();
   private activeSurfaceTextureKey?: string;
   private activeAnimation?: DoorAnimationId;
-  private activeHandleGroup?: THREE.Group;
+  private activeHandleGroups: Array<{
+    group: THREE.Group;
+    rotationMultiplier: number;
+  }> = [];
   private doorMaterials = createDoorMaterials();
+  private frontDoorMaterial = createDoorFaceMaterial();
+  private backDoorMaterial = createDoorFaceMaterial();
   private handleMaterial = createHandleMaterial();
+  private disposed = false;
 
   constructor(className: string) {
     this.element = document.createElement("div");
@@ -220,10 +233,13 @@ class VanillaDoorScene {
   }
 
   dispose() {
+    this.disposed = true;
     this.resizeObserver?.disconnect();
     disposeObject(this.doorRoot);
     this.scene.remove(this.doorRoot);
     this.doorMaterials.forEach((material) => material.dispose());
+    this.frontDoorMaterial.dispose();
+    this.backDoorMaterial.dispose();
     this.handleMaterial.dispose();
     this.renderer.dispose();
     this.element.remove();
@@ -253,44 +269,48 @@ class VanillaDoorScene {
     this.scene.remove(this.doorRoot);
     this.doorRoot = new THREE.Group();
     this.scene.add(this.doorRoot);
-    this.activeHandleGroup = undefined;
+    this.activeHandleGroups = [];
 
     this.doorMaterials = createDoorMaterials();
+    this.frontDoorMaterial = createDoorFaceMaterial();
+    this.backDoorMaterial = createDoorFaceMaterial();
     this.handleMaterial = createHandleMaterial();
     const doorMaterials = this.doorMaterials;
-    this.loadTexture(surfaceTextureUrls.frontTextureUrl, [4], doorMaterials);
-    this.loadTexture(surfaceTextureUrls.edgeTextureUrl, [0, 1, 2, 3], doorMaterials);
-    this.loadTexture(surfaceTextureUrls.backTextureUrl, [5], doorMaterials);
-
-    this.addFrame();
+    this.loadTexture(surfaceTextureUrls.edgeTextureUrl, doorMaterials.slice(0, 4));
+    this.loadTexture(surfaceTextureUrls.frontTextureUrl, [this.frontDoorMaterial]);
+    this.loadTexture(surfaceTextureUrls.backTextureUrl, [this.backDoorMaterial]);
 
     if (animation === "double-swing") {
       const left = this.createDoorLeaf({
-        width: 1.48,
-        height: 5.2,
-        pivotX: 0,
+        width: 3,
+        height: 6,
+        pivotX: -3,
+        doorCenterX: 1.5,
+        handleX: 2.26,
         side: "left",
       });
       left.name = "left-door";
-      left.position.x = -0.02;
       this.doorRoot.add(left);
 
       const right = this.createDoorLeaf({
-        width: 1.48,
-        height: 5.2,
-        pivotX: 0,
+        width: 3,
+        height: 6,
+        pivotX: 3,
+        doorCenterX: -1.5,
+        handleX: -2.26,
         side: "right",
       });
       right.name = "right-door";
-      right.position.x = 0.02;
       this.doorRoot.add(right);
       return;
     }
 
     const single = this.createDoorLeaf({
       width: 3,
-      height: 5.2,
+      height: 6,
       pivotX: -1.5,
+      doorCenterX: 1.5,
+      handleX: 2.26,
       side: "single",
     });
     single.name = "single-door";
@@ -299,53 +319,39 @@ class VanillaDoorScene {
 
   private loadTexture(
     url: string,
-    materialIndexes: number[],
-    materials: typeof this.doorMaterials
+    materials: THREE.MeshStandardMaterial[]
   ) {
     this.textureLoader.load(url, (texture) => {
-      texture.wrapS = THREE.RepeatWrapping;
-      texture.wrapT = THREE.RepeatWrapping;
-      materialIndexes.forEach((index) => {
-        const material = materials[index];
+      if (this.disposed) {
+        texture.dispose();
+        return;
+      }
+
+      texture.wrapS = THREE.ClampToEdgeWrapping;
+      texture.wrapT = THREE.ClampToEdgeWrapping;
+      texture.flipY = false;
+      texture.needsUpdate = true;
+      materials.forEach((material) => {
         material.map = texture;
         material.needsUpdate = true;
       });
+      this.renderer.render(this.scene, this.camera);
     });
-  }
-
-  private addFrame() {
-    const frameMaterial = new THREE.MeshStandardMaterial({
-      color: "#171717",
-      roughness: 0.85,
-      metalness: 0.15,
-    });
-    const top = new THREE.Mesh(new THREE.BoxGeometry(3.55, 0.28, 0.28), frameMaterial);
-    top.position.set(0, 2.75, -0.08);
-    const left = new THREE.Mesh(new THREE.BoxGeometry(0.28, 5.6, 0.28), frameMaterial);
-    left.position.set(-1.78, 0, -0.08);
-    const right = new THREE.Mesh(new THREE.BoxGeometry(0.28, 5.6, 0.28), frameMaterial);
-    right.position.set(1.78, 0, -0.08);
-    const floor = new THREE.Mesh(
-      new THREE.BoxGeometry(5.2, 0.08, 4),
-      new THREE.MeshStandardMaterial({
-        color: "#24211e",
-        roughness: 0.8,
-        metalness: 0.08,
-      })
-    );
-    floor.position.set(0, -2.72, 0.8);
-    this.doorRoot.add(top, left, right, floor);
   }
 
   private createDoorLeaf({
     width,
     height,
     pivotX,
+    doorCenterX,
+    handleX,
     side,
   }: {
     width: number;
     height: number;
     pivotX: number;
+    doorCenterX: number;
+    handleX: number;
     side: "single" | "left" | "right";
   }) {
     const pivot = new THREE.Group();
@@ -355,27 +361,26 @@ class VanillaDoorScene {
       new THREE.BoxGeometry(width, height, 0.16),
       this.doorMaterials
     );
-    const doorOffset = side === "right" ? width / 2 : -pivotX + width / 2 - 1.5;
-    door.position.set(side === "left" ? -width / 2 : doorOffset, 0, 0);
+    door.position.set(doorCenterX, 0, 0.08);
     pivot.add(door);
 
-    const bevel = new THREE.Mesh(
-      new THREE.BoxGeometry(width * 0.82, height * 0.72, 0.04),
-      new THREE.MeshStandardMaterial({
-        color: "#000000",
-        roughness: 0.85,
-        metalness: 0.05,
-        transparent: true,
-        opacity: 0.22,
-      })
+    const front = new THREE.Mesh(
+      new THREE.PlaneGeometry(width, height),
+      this.frontDoorMaterial
     );
-    bevel.position.set(door.position.x, 0, 0.105);
-    pivot.add(bevel);
+    front.position.set(doorCenterX, 0, 0.161);
+    pivot.add(front);
+
+    const back = new THREE.Mesh(
+      new THREE.PlaneGeometry(width, height),
+      this.backDoorMaterial
+    );
+    back.position.set(doorCenterX, 0, -0.001);
+    back.rotation.y = Math.PI;
+    pivot.add(back);
 
     const handleGroup = new THREE.Group();
-    const handleX =
-      side === "left" ? -width + 0.32 : side === "right" ? width - 0.32 : 1.08;
-    handleGroup.position.set(handleX, -0.1, 0.22);
+    handleGroup.position.set(handleX, -0.02, 0.22);
     const stem = new THREE.Mesh(
       new THREE.CylinderGeometry(0.08, 0.08, 0.12, 24),
       this.handleMaterial
@@ -389,29 +394,30 @@ class VanillaDoorScene {
     handleGroup.add(stem, lever);
     pivot.add(handleGroup);
 
-    if (side === "single" || side === "right") {
-      this.activeHandleGroup = handleGroup;
-    }
+    this.activeHandleGroups.push({
+      group: handleGroup,
+      rotationMultiplier: side === "left" ? 1 : -1,
+    });
 
     return pivot;
   }
 
   private applyDoorState(animation: DoorAnimationId, state: DoorAnimationState) {
-    const maxAngle = Math.PI * 0.58;
+    const maxAngle = Math.PI / 2;
     const left = this.doorRoot.getObjectByName("left-door");
     const right = this.doorRoot.getObjectByName("right-door");
     const single = this.doorRoot.getObjectByName("single-door");
 
     if (animation === "double-swing") {
-      if (left) left.rotation.y = state.doorAngle * maxAngle;
-      if (right) right.rotation.y = -(state.rightDoorAngle ?? state.doorAngle) * maxAngle;
+      if (left) left.rotation.y = -state.doorAngle * maxAngle;
+      if (right) right.rotation.y = (state.rightDoorAngle ?? state.doorAngle) * maxAngle;
     } else if (single) {
       single.rotation.y = -state.doorAngle * maxAngle;
     }
 
-    if (this.activeHandleGroup) {
-      this.activeHandleGroup.rotation.z = -(state.handleAngle ?? 0);
-    }
+    this.activeHandleGroups.forEach(({ group, rotationMultiplier }) => {
+      group.rotation.z = (state.handleAngle ?? 0) * rotationMultiplier;
+    });
   }
 
   private applyCameraState(
@@ -445,6 +451,8 @@ export const mountDoorEntrance = (
   let soundFrame: number | null = null;
   let audioDelayTimer: number | null = null;
   let soundStarted = false;
+  let soundUnlocked = false;
+  let soundUnlocking: Promise<boolean> | null = null;
   let disposed = false;
 
   const scene = new VanillaDoorScene(
@@ -587,6 +595,35 @@ export const mountDoorEntrance = (
     soundStarted = false;
   };
 
+  const unlockSound = () => {
+    if (!resolvedSoundUrl || soundUnlocked) {
+      return Promise.resolve(soundUnlocked);
+    }
+
+    if (soundUnlocking) return soundUnlocking;
+
+    const wasMuted = audio.muted;
+    audio.muted = true;
+    soundUnlocking = audio
+      .play()
+      .then(() => {
+        audio.pause();
+        audio.currentTime = 0;
+        audio.muted = wasMuted;
+        soundUnlocked = true;
+        return true;
+      })
+      .catch(() => {
+        audio.muted = wasMuted;
+        return false;
+      })
+      .finally(() => {
+        soundUnlocking = null;
+      });
+
+    return soundUnlocking;
+  };
+
   const resetSound = () => {
     audio.pause();
     if (Number.isFinite(audio.duration) && audio.duration > 0) {
@@ -646,6 +683,7 @@ export const mountDoorEntrance = (
     if (resolvedSoundUrl && audio.src !== resolvedSoundUrl) {
       audio.src = resolvedSoundUrl;
       audio.preload = "auto";
+      soundUnlocked = false;
     }
     return activeConfig;
   };
@@ -654,26 +692,38 @@ export const mountDoorEntrance = (
     clearAudioDelayTimer();
     soundStarted = false;
 
-    if (!resolvedSoundUrl || !Number.isFinite(audio.duration) || audio.duration <= 0) {
+    if (!resolvedSoundUrl) {
       emitSoundProgress();
       return;
     }
 
     const { startProgress: soundStartProgress } = getSoundWindow(config);
     const playNow = () => {
-      syncSoundToTimelineProgress(
-        Math.max(startProgress, soundStartProgress),
-        config
-      );
-      void audio
-        .play()
-        .then(() => {
-          soundStarted = true;
-          startSoundLoop();
-        })
-        .catch(() => {
-          soundStarted = false;
+      const startPlayback = () => {
+        syncSoundToTimelineProgress(
+          Math.max(startProgress, soundStartProgress),
+          config
+        );
+        void audio
+          .play()
+          .then(() => {
+            syncSoundToTimelineProgress(progress, config);
+            soundStarted = true;
+            startSoundLoop();
+          })
+          .catch(() => {
+            soundStarted = false;
+          });
+      };
+
+      if (!soundUnlocked) {
+        void unlockSound().then((unlocked) => {
+          if (unlocked && !disposed && isAnimating) startPlayback();
         });
+        return;
+      }
+
+      startPlayback();
     };
 
     if (startProgress >= soundStartProgress) {
@@ -698,6 +748,7 @@ export const mountDoorEntrance = (
         renderProgress(startProgress, config);
       }
 
+      void unlockSound();
       playSoundForTimeline(startProgress, config);
       const duration = Math.max(config.duration * (1 - startProgress), 1);
       const startTime = performance.now();

--- a/packages/door-lib/tests/browser/preset-catalog.test.ts
+++ b/packages/door-lib/tests/browser/preset-catalog.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+test("preset catalog opens and closes a vanilla detail modal", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const panelPreview = page.getByRole("img", {
+    name: "Single Lever Wood animation preview",
+  });
+  await expect(panelPreview).toBeVisible();
+  await expect(panelPreview.locator("canvas")).toBeVisible();
+  await expect(
+    page.getByRole("img", { name: "Double Lever Wood animation preview" })
+  ).toHaveCount(1);
+
+  await page
+    .getByRole("button", { name: "Open Single Lever Wood" })
+    .click();
+
+  const dialog = page.getByRole("dialog", { name: "Single Lever Wood" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator("canvas")).toBeVisible();
+
+  await page.getByRole("button", { name: "Close preset detail" }).click();
+
+  await expect(dialog).toHaveCount(0);
+  await expect(page.locator("canvas")).toHaveCount(3);
+});
+
+test("preset detail lets users scrub the animation timeline", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Open Single Lever Wood" })
+    .click();
+
+  const timeline = page.getByRole("slider", {
+    name: "Animation progress",
+  });
+  await expect(timeline).toHaveValue("0");
+
+  await timeline.fill("50");
+  await expect(timeline).toHaveValue("50");
+  await expect(page.getByText("50%", { exact: true })).toBeVisible();
+});
+
+test("mobile preset detail keeps its close control within the viewport", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Open Single Lever Wood" })
+    .click();
+
+  const closeButton = page.getByRole("button", {
+    name: "Close preset detail",
+  });
+  const bounds = await closeButton.boundingBox();
+
+  expect(bounds).not.toBeNull();
+  expect(bounds?.x).toBeGreaterThanOrEqual(0);
+  expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(390);
+});

--- a/packages/door-lib/tests/browser/vanilla-smoke.test.ts
+++ b/packages/door-lib/tests/browser/vanilla-smoke.test.ts
@@ -57,3 +57,18 @@ test("vanilla sample renders and responds to playback controls", async ({
   await page.evaluate(() => window.__doorEntranceTestApi__?.unmount());
   await expect(canvas).toHaveCount(0);
 });
+
+test("vanilla sample starts the door sound after a user plays the animation", async ({
+  page,
+}) => {
+  await page.goto("/samples/vanilla.html?testMode");
+  await page.waitForFunction(() => window.__doorEntranceTestApi__?.ready());
+
+  await page.locator("#door-play").click();
+
+  await expect
+    .poll(async () =>
+      page.locator("audio").evaluate((audio) => !audio.paused)
+    )
+    .toBe(true);
+});

--- a/packages/sample/src/pages/Index.tsx
+++ b/packages/sample/src/pages/Index.tsx
@@ -1,136 +1,105 @@
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { doorEntrancePresets } from "retro-horror-door";
-import { Link } from "react-router-dom";
+import { useCallback, useState } from "react";
+import { ArrowUpRight } from "lucide-react";
+import {
+  doorEntrancePresets,
+  type DoorEntrancePresetId,
+} from "retro-horror-door";
+import PresetDetailModal from "./PresetDetailModal";
+import PresetAnimationPreview from "./PresetAnimationPreview";
 
-const htmlSnippet = `<div id="door-root"></div>
-<script type="module">
-  import { mountDoorEntrance } from 'retro-horror-door';
-
-  mountDoorEntrance({
-    target: document.getElementById('door-root'),
-    preset: 'single-lever-wood',
-    autoPlay: true,
-  });
-</script>`;
-
-const CodeBlock = ({ code }: { code: string }) => (
-  <pre className="overflow-auto rounded-xl border border-white/10 bg-black/60 p-4 text-sm leading-relaxed text-emerald-100 shadow-inner shadow-black/40">
-    <code>{code}</code>
-  </pre>
-);
+const formatValue = (value: string) =>
+  value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 
 const Index = () => {
+  const [selectedPresetId, setSelectedPresetId] =
+    useState<DoorEntrancePresetId | null>(null);
+  const selectedPreset = doorEntrancePresets.find(
+    (preset) => preset.id === selectedPresetId
+  );
+  const closeDetail = useCallback(() => setSelectedPresetId(null), []);
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-black to-slate-900 text-white">
-      <div className="mx-auto flex w-full max-w-none flex-col gap-10 px-4 py-8 sm:px-6">
-        <header className="space-y-4">
-          <Badge variant="outline" className="border-emerald-500/60 text-emerald-200">
-            vanilla module ready
-          </Badge>
-          <h1 className="text-3xl font-bold sm:text-4xl">
-            門入場動畫 Library
-          </h1>
-          <p className="max-w-3xl text-lg text-white/70">
-            門動畫以可播放 preset 封裝，並透過 vanilla mount helper
-            掛載到任意 DOM 節點。
+    <main className="min-h-screen bg-[#070504] text-[#e9dfcd]">
+      <div className="mx-auto w-full max-w-7xl px-5 py-12 sm:px-8 sm:py-16 lg:px-10 lg:py-20">
+        <header className="max-w-3xl border-l border-[#b77a38]/70 pl-5 sm:pl-7">
+          <p className="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[#c58a45]">
+            Retro Horror Door / {String(doorEntrancePresets.length).padStart(2, "0")} presets
           </p>
-          <div className="flex flex-wrap gap-2 text-sm text-white/60">
-            {doorEntrancePresets.map((preset) => (
-              <span
-                key={preset.id}
-                className="rounded-full border border-white/10 px-3 py-1"
-              >
-                {preset.id}
-              </span>
-            ))}
-          </div>
+          <h1 className="font-[Georgia,serif] text-4xl leading-[1.04] text-[#f1e7d6] sm:text-5xl lg:text-6xl">
+            Playable door presets
+          </h1>
+          <p className="mt-5 max-w-2xl text-sm leading-7 text-[#aa9f90] sm:text-base">
+            每張卡代表一組已定義、可發布的門組合。開啟 preset 以檢視實際播放與其固定設定。
+          </p>
         </header>
 
-        <section className="space-y-4">
-          <div className="space-y-2">
-            <h2 className="text-2xl font-semibold">Door PoCs</h2>
-            <p className="max-w-3xl text-sm text-white/65">
-              針對原本被判不可做或高風險的門型，做最小可驗證原型。
-            </p>
-          </div>
+        <section
+          aria-label="Available door presets"
+          className="mt-10 grid gap-5 sm:grid-cols-2 lg:mt-14 lg:grid-cols-3"
+        >
+          {doorEntrancePresets.map((preset) => (
+              <article
+                key={preset.id}
+                className="flex min-h-[340px] flex-col overflow-hidden border border-[#5f4933]/60 bg-[#0c0907]"
+              >
+                <div
+                  className="relative h-64 min-h-0 overflow-hidden border-b border-[#5f4933]/45 bg-[#090705]"
+                >
+                  <PresetAnimationPreview preset={preset} />
+                  <span className="absolute left-4 top-4 border border-[#c58a45]/55 bg-[#080604]/90 px-2.5 py-1 text-[0.65rem] font-bold tracking-[0.18em] text-[#d8a05a]">
+                    {formatValue(preset.type)}
+                  </span>
+                </div>
 
-          <div className="grid gap-6 md:grid-cols-2">
-            <Card className="border-white/10 bg-white/[0.04] shadow-lg shadow-black/30">
-              <CardHeader className="space-y-2">
-                <Badge variant="outline" className="w-fit border-amber-500/60 text-amber-200">
-                  1-2 a04
-                </Badge>
-                <CardTitle className="text-lg">單門-粗把手</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <p className="text-sm text-white/70">
-                  共用單門骨架切換 s1 柵欄鐵門 / s2 目字鐵門，驗證兩者都可用低複雜度幾何成立。
-                </p>
-                <Button asChild variant="secondary" size="sm">
-                  <Link to="/poc/a04">開啟 POC</Link>
-                </Button>
-              </CardContent>
-            </Card>
-
-            <Card className="border-white/10 bg-white/[0.04] shadow-lg shadow-black/30">
-              <CardHeader className="space-y-2">
-                <Badge variant="outline" className="w-fit border-amber-500/60 text-amber-200">
-                  1-2 a11
-                </Badge>
-                <CardTitle className="text-lg">重型水門</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <p className="text-sm text-white/70">
-                  Primitive 疊加 + 程序材質，驗證浮凸水門不需外找模型。
-                </p>
-                <Button asChild variant="secondary" size="sm">
-                  <Link to="/poc/a11">開啟 POC</Link>
-                </Button>
-              </CardContent>
-            </Card>
-
-            <Card className="border-white/10 bg-white/[0.04] shadow-lg shadow-black/30">
-              <CardHeader className="space-y-2">
-                <Badge variant="outline" className="w-fit border-amber-500/60 text-amber-200">
-                  1-2 b10
-                </Badge>
-                <CardTitle className="text-lg">下水道閘門</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <p className="text-sm text-white/70">
-                  Shape 輪廓擠出 + 上下對開，驗證齒形閘門可用程式幾何製作。
-                </p>
-                <Button asChild variant="secondary" size="sm">
-                  <Link to="/poc/b10">開啟 POC</Link>
-                </Button>
-              </CardContent>
-            </Card>
-          </div>
+                <div className="flex flex-1 flex-col p-5 sm:p-6">
+                  <h2 className="font-[Georgia,serif] text-2xl leading-tight text-[#eee2d0]">
+                    {preset.label}
+                  </h2>
+                  <p className="mt-2 font-mono text-xs text-[#a89d8e]">{preset.id}</p>
+                  <dl className="mt-5 grid grid-cols-2 gap-x-4 gap-y-3 text-xs">
+                    <div>
+                      <dt className="text-[#756958]">Motion</dt>
+                      <dd className="mt-1 text-[#d8c9b5]">{formatValue(preset.motion)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-[#756958]">Handle</dt>
+                      <dd className="mt-1 text-[#d8c9b5]">
+                        {preset.handleProfileId
+                          ? formatValue(preset.handleProfileId)
+                          : "None"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-[#756958]">Material</dt>
+                      <dd className="mt-1 text-[#d8c9b5]">{formatValue(preset.material)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-[#756958]">Animation</dt>
+                      <dd className="mt-1 text-[#d8c9b5]">{formatValue(preset.animation)}</dd>
+                    </div>
+                  </dl>
+                  <button
+                    type="button"
+                    aria-label={`Open ${preset.label}`}
+                    onClick={() => setSelectedPresetId(preset.id)}
+                    className="mt-auto flex items-center justify-between border-t border-[#4b3928]/65 pt-5 text-left text-xs font-semibold uppercase tracking-[0.14em] text-[#c98d48] transition-colors hover:text-[#f0bd78] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-offset-4 focus-visible:ring-offset-[#0c0907]"
+                  >
+                    Open preset
+                    <ArrowUpRight aria-hidden="true" size={16} />
+                  </button>
+                </div>
+              </article>
+          ))}
         </section>
-
-        <div className="max-w-3xl">
-          <Card className="border-white/10 bg-white/[0.04] shadow-lg shadow-black/30">
-            <CardHeader className="flex items-center justify-between gap-3">
-              <CardTitle className="text-lg">HTML 引入</CardTitle>
-              <Button asChild variant="secondary" size="sm">
-                <a href="/samples/vanilla.html" target="_blank" rel="noreferrer">
-                  開啟 sample
-                </a>
-              </Button>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-sm text-white/70">
-                使用 `mountDoorEntrance` 將 vanilla renderer 掛在任意 DOM 節點。Sample 頁面在
-                <code className="mx-1 rounded bg-white/10 px-1 py-0.5 text-xs">public/samples/vanilla.html</code>，啟動 `npm run dev` 後可直接開啟。
-              </p>
-              <CodeBlock code={htmlSnippet} />
-            </CardContent>
-          </Card>
-        </div>
       </div>
-    </div>
+
+      {selectedPreset && (
+        <PresetDetailModal preset={selectedPreset} onClose={closeDetail} />
+      )}
+    </main>
   );
 };
 

--- a/packages/sample/src/pages/PresetAnimationPreview.tsx
+++ b/packages/sample/src/pages/PresetAnimationPreview.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import {
+  mountDoorEntrance,
+  type DoorEntranceHandle,
+  type DoorEntrancePreset,
+} from "retro-horror-door";
+
+type PresetAnimationPreviewProps = {
+  preset: DoorEntrancePreset;
+};
+
+const PresetAnimationPreview = ({ preset }: PresetAnimationPreviewProps) => {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    const door: DoorEntranceHandle = mountDoorEntrance({
+      target,
+      preset: preset.id,
+      autoPlay: false,
+      className: "h-full min-h-0 w-full border-0 bg-black",
+    });
+
+    return () => door.unmount();
+  }, [preset.id]);
+
+  return (
+    <div
+      role="img"
+      aria-label={`${preset.label} animation preview`}
+      className="relative h-full min-h-0 w-full overflow-hidden bg-black"
+    >
+      <div ref={targetRef} className="absolute inset-0" />
+    </div>
+  );
+};
+
+export default PresetAnimationPreview;

--- a/packages/sample/src/pages/PresetDetailModal.tsx
+++ b/packages/sample/src/pages/PresetDetailModal.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import {
+  getDoorAnimationConfig,
+  mountDoorEntrance,
+  type DoorEntranceHandle,
+  type DoorEntrancePreset,
+} from "retro-horror-door";
+
+type PresetDetailModalProps = {
+  preset: DoorEntrancePreset;
+  onClose: () => void;
+};
+
+const formatValue = (value: string) =>
+  value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+const formatTime = (milliseconds: number) => {
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+};
+
+const PresetDetailModal = ({ preset, onClose }: PresetDetailModalProps) => {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const doorRef = useRef<DoorEntranceHandle | null>(null);
+  const [ready, setReady] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const animation = getDoorAnimationConfig(preset.animation);
+  const progressPercent = Math.round(progress * 100);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    setReady(false);
+    setProgress(0);
+    const door = mountDoorEntrance({
+      target,
+      preset: preset.id,
+      autoPlay: false,
+      className: "h-full min-h-[360px] w-full border-0 bg-black",
+      onReady: () => setReady(true),
+      onProgress: setProgress,
+    });
+    doorRef.current = door;
+
+    return () => {
+      door.unmount();
+      doorRef.current = null;
+    };
+  }, [preset.id]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const play = () => {
+    const door = doorRef.current;
+    if (!door || !ready) return;
+
+    door.play(preset.id);
+  };
+
+  const reset = () => {
+    setProgress(0);
+    doorRef.current?.reset(preset.id);
+  };
+
+  const seek = (nextProgress: number) => {
+    const clampedProgress = Math.min(Math.max(nextProgress, 0), 1);
+    setProgress(clampedProgress);
+    doorRef.current?.seek(clampedProgress, preset.id);
+  };
+  const usageSnippet = `mountDoorEntrance({\n  target: document.getElementById("door-root"),\n  preset: "${preset.id}",\n  autoPlay: true,\n});`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-3 sm:p-6"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="preset-detail-title"
+        className="grid max-h-full w-full max-w-6xl overflow-auto border border-[#5f4933] bg-[#0c0907] lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.75fr)]"
+      >
+        <div className="relative min-h-[360px] bg-black sm:min-h-[520px]">
+          <div ref={targetRef} className="absolute inset-0" />
+        </div>
+
+        <div className="flex min-w-0 min-h-[360px] flex-col border-t border-[#5f4933] p-5 sm:p-7 lg:border-l lg:border-t-0">
+          <div className="flex items-start justify-between gap-5">
+            <div className="min-w-0">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#c98d48]">
+                Selected preset
+              </p>
+              <h2
+                id="preset-detail-title"
+                className="mt-2 break-words font-[Georgia,serif] text-2xl leading-tight text-[#eee2d0] sm:text-3xl"
+              >
+                {preset.label}
+              </h2>
+              <p className="mt-2 font-mono text-xs text-[#aa9f90]">{preset.id}</p>
+            </div>
+            <button
+              type="button"
+              aria-label="Close preset detail"
+              title="Close preset detail"
+              onClick={onClose}
+              className="grid h-9 w-9 shrink-0 place-items-center border border-[#5f4933] text-[#d8c9b5] transition-colors hover:border-[#c98d48] hover:text-[#f1e7d6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952]"
+            >
+              <X aria-hidden="true" size={18} />
+            </button>
+          </div>
+
+          <dl className="mt-7 grid grid-cols-[auto_1fr] gap-x-5 gap-y-2 border-y border-[#4b3928] py-5 text-sm">
+            <dt className="text-[#827665]">Type</dt>
+            <dd className="text-[#dfd2bf]">{formatValue(preset.type)}</dd>
+            <dt className="text-[#827665]">Motion</dt>
+            <dd className="text-[#dfd2bf]">{formatValue(preset.motion)}</dd>
+            <dt className="text-[#827665]">Handle</dt>
+            <dd className="text-[#dfd2bf]">
+              {preset.handleProfileId
+                ? formatValue(preset.handleProfileId)
+                : "None"}
+            </dd>
+            <dt className="text-[#827665]">Material</dt>
+            <dd className="text-[#dfd2bf]">{formatValue(preset.material)}</dd>
+            <dt className="text-[#827665]">Animation</dt>
+            <dd className="text-[#dfd2bf]">{formatValue(preset.animation)}</dd>
+          </dl>
+
+          <div className="mt-5 flex gap-2">
+            <button
+              type="button"
+              onClick={play}
+              disabled={!ready}
+              className="border border-[#c98d48] bg-[#c98d48] px-4 py-2 text-sm font-bold text-[#100c08] transition-colors hover:bg-[#dda762] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Play
+            </button>
+            <button
+              type="button"
+              onClick={reset}
+              className="border border-[#8d683e] px-4 py-2 text-sm font-semibold text-[#ddc6a8] transition-colors hover:border-[#c98d48] hover:text-[#f1e7d6]"
+            >
+              Reset
+            </button>
+          </div>
+
+          <section className="mt-6 border-y border-[#4b3928] py-4" aria-label="Animation timeline">
+            <div className="flex items-center justify-between gap-4 text-xs text-[#aa9f90]">
+              <span>{formatTime(animation.duration * progress)}</span>
+              <span>{formatTime(animation.duration)}</span>
+            </div>
+            <div className="relative mt-2">
+              <input
+                aria-label="Animation progress"
+                type="range"
+                min="0"
+                max="100"
+                step="0.1"
+                value={progress * 100}
+                disabled={!ready}
+                onChange={(event) => seek(Number(event.target.value) / 100)}
+                className="h-2 w-full cursor-ew-resize appearance-none rounded-full accent-[#c98d48] disabled:cursor-not-allowed"
+                style={{
+                  background: `linear-gradient(to right, #c98d48 0%, #c98d48 ${progress * 100}%, #4b3928 ${progress * 100}%, #4b3928 100%)`,
+                }}
+              />
+              <div className="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2">
+                {animation.progressMarkers.map((marker) => (
+                  <span
+                    key={marker}
+                    className="absolute h-3 w-px bg-[#e3d2bd]/55"
+                    style={{ left: `${marker * 100}%` }}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="mt-2 flex items-center justify-between text-[0.68rem] text-[#827665]">
+              <span>{progressPercent}%</span>
+              <span>
+                {animation.progressMarkers
+                  .map((marker) => `${Math.round(marker * 100)}%`)
+                  .join(" · ")}
+              </span>
+            </div>
+          </section>
+
+          <pre className="mt-6 overflow-x-auto border border-[#4b3928] bg-[#090705] p-4 text-xs leading-6 text-[#d8c9b5]">
+            <code>{usageSnippet}</code>
+          </pre>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default PresetDetailModal;


### PR DESCRIPTION
## Summary
- replace the sample PoC homepage with a playable preset catalog and modal detail view
- align the vanilla door renderer with the original hinge geometry, independent front/back/edge textures, and no frame or floor
- render catalog previews with the same vanilla renderer and restore timeline scrubbing
- make delayed door audio work when Play is pressed before audio metadata is available

## Verification
- 
> retro-horror-door-monorepo@0.0.0 test:lib:browser
> npm run test:browser --workspace retro-horror-door


> retro-horror-door@0.1.0 test:browser
> npm run build && playwright test --config tests/browser/playwright.config.ts


> retro-horror-door@0.1.0 build
> tsup

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/door-lib/tsup.config.ts
CLI Building entry: src/vanilla.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/door-lib/tsup.config.ts
CLI Target: es2020
CLI Target: es2020
ESM Build start
CJS Build start
CLI Cleaning output folder
ESM Build start
CJS Build start
ESM dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
ESM dist/index.js                                                         33.63 KB
ESM dist/door-1-NYF7EVQC.png                                              336.76 KB
ESM dist/index.js.map                                                     61.83 KB
ESM ⚡️ Build success in 61ms
ESM dist/door-1-NYF7EVQC.png                                              336.76 KB
ESM dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
ESM dist/vanilla.js                                                       33.41 KB
ESM dist/vanilla.js.map                                                   61.83 KB
ESM ⚡️ Build success in 68ms
CJS dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
CJS dist/door-1-NYF7EVQC.png                                              336.76 KB
CJS dist/vanilla.cjs                                                      35.17 KB
CJS dist/vanilla.cjs.map                                                  61.81 KB
CJS ⚡️ Build success in 69ms
CJS dist/door-1-NYF7EVQC.png                                              336.76 KB
CJS dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
CJS dist/index.cjs                                                        35.89 KB
CJS dist/index.cjs.map                                                    62.78 KB
CJS ⚡️ Build success in 62ms
DTS Build start
DTS Build start
DTS ⚡️ Build success in 2465ms
DTS dist/index.d.ts  4.49 KB
DTS dist/index.d.cts 4.49 KB
DTS ⚡️ Build success in 2473ms
DTS dist/vanilla.d.ts  1.65 KB
DTS dist/vanilla.d.cts 1.65 KB

Running 5 tests using 2 workers

  ✓  2 tests/browser/vanilla-smoke.test.ts:20:1 › vanilla sample renders and responds to playback controls (1.4s)
  ✓  3 tests/browser/vanilla-smoke.test.ts:61:1 › vanilla sample starts the door sound after a user plays the animation (687ms)
  ✓  1 tests/browser/preset-catalog.test.ts:3:1 › preset catalog opens and closes a vanilla detail modal (2.2s)
  ✓  4 tests/browser/preset-catalog.test.ts:31:1 › preset detail lets users scrub the animation timeline (1.6s)
  ✓  5 tests/browser/preset-catalog.test.ts:49:1 › mobile preset detail keeps its close control within the viewport (1.6s)

  5 passed (7.2s)
- 
> retro-horror-door-monorepo@0.0.0 test:lib:package
> npm run test:package --workspace retro-horror-door


> retro-horror-door@0.1.0 test:package
> npm run build && node --disable-warning=ExperimentalWarning --experimental-strip-types --test src/__tests__/package-boundary.test.ts


> retro-horror-door@0.1.0 build
> tsup

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/door-lib/tsup.config.ts
CLI Building entry: src/vanilla.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/door-lib/tsup.config.ts
CLI Target: es2020
CLI Target: es2020
ESM Build start
CJS Build start
CLI Cleaning output folder
ESM Build start
CJS Build start
CJS dist/vanilla.cjs                                                      35.17 KB
CJS dist/door-1-NYF7EVQC.png                                              336.76 KB
CJS dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
CJS dist/vanilla.cjs.map                                                  61.81 KB
CJS ⚡️ Build success in 29ms
ESM dist/door-1-NYF7EVQC.png                                              336.76 KB
ESM dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
ESM dist/index.js                                                         33.63 KB
ESM dist/index.js.map                                                     61.83 KB
ESM ⚡️ Build success in 23ms
CJS dist/index.cjs                                                        35.89 KB
CJS dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
CJS dist/door-1-NYF7EVQC.png                                              336.76 KB
CJS dist/index.cjs.map                                                    62.78 KB
CJS ⚡️ Build success in 24ms
ESM dist/door-1-NYF7EVQC.png                                              336.76 KB
ESM dist/vanilla.js                                                       33.41 KB
ESM dist/freesound_community-main-door-opening-closing-38280-F6TCO3MG.mp3 195.00 KB
ESM dist/vanilla.js.map                                                   61.83 KB
ESM ⚡️ Build success in 30ms
DTS Build start
DTS Build start
DTS ⚡️ Build success in 1144ms
DTS dist/vanilla.d.ts  1.65 KB
DTS dist/vanilla.d.cts 1.65 KB
DTS ⚡️ Build success in 1212ms
DTS dist/index.d.ts  4.49 KB
DTS dist/index.d.cts 4.49 KB
TAP version 13
# Subtest: package boundary
    # Subtest: does not publish the removed React adapter or its peer dependencies
    ok 1 - does not publish the removed React adapter or its peer dependencies
      ---
      duration_ms: 0.818416
      type: 'test'
      ...
    # Subtest: keeps the root package entry React-free by default
    ok 2 - keeps the root package entry React-free by default
      ---
      duration_ms: 2.39825
      type: 'test'
      ...
    # Subtest: publishes the vanilla entry
    ok 3 - publishes the vanilla entry
      ---
      duration_ms: 0.135708
      type: 'test'
      ...
    # Subtest: publishes the preset registry from the root entry
    ok 4 - publishes the preset registry from the root entry
      ---
      duration_ms: 0.167334
      type: 'test'
      ...
    # Subtest: keeps the vanilla renderer limited to the door and its handle
    ok 5 - keeps the vanilla renderer limited to the door and its handle
      ---
      duration_ms: 0.122709
      type: 'test'
      ...
    # Subtest: keeps vanilla hinge geometry aligned with the original door behavior
    ok 6 - keeps vanilla hinge geometry aligned with the original door behavior
      ---
      duration_ms: 0.270875
      type: 'test'
      ...
    # Subtest: keeps the full vanilla output graph React-free
    ok 7 - keeps the full vanilla output graph React-free
      ---
      duration_ms: 0.97375
      type: 'test'
      ...
    1..7
ok 1 - package boundary
  ---
  duration_ms: 5.547125
  type: 'suite'
  ...
1..1
# tests 7
# suites 1
# pass 7
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 99.31675
- 
> retro-horror-door-monorepo@0.0.0 lint
> npm run lint --workspace retro-horror-door && npm run lint --workspace retro-horror-door-sample


> retro-horror-door@0.1.0 lint
> tsc --noEmit


> retro-horror-door-sample@0.0.0 lint
> eslint .


/Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/sample/src/components/ui/badge.tsx
  29:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/sample/src/components/ui/button.tsx
  47:18  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/mujingtsai/Case/BioHazard/re-canvas-door-swing/.worktrees/preset-catalog-modal/packages/sample/src/components/ui/sonner.tsx
  27:19  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

✖ 3 problems (0 errors, 3 warnings) (3 pre-existing Fast Refresh warnings in sample UI files)