### PR TITLE
docs: sync preset catalog documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,75 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-The Vite + React entry point sits in `src/main.tsx`, bootstrapping routes defined in `src/App.tsx`. Route-level views belong in `src/pages/`, reusable building blocks in `src/components/`, shared stateful logic in `src/hooks/`, and lightweight utilities in `src/lib/`. UI primitives from shadcn live under `src/components/ui/`. Static textures and other assets reside in `public/`, while build and styling configuration is centralized in `vite.config.ts`, `tailwind.config.ts`, and `postcss.config.js`.
+## Project Structure
 
-## Build, Test, and Development Commands
-Install dependencies with `npm install`. Run `npm run dev` for the hot-reloading development server, or `npm run preview` to inspect the production build locally after running `npm run build`. Use `npm run build:dev` when you need a production bundle that still targets development services. Execute `npm run lint` before every push to surface TypeScript and React issues.
+The repository is an npm workspaces monorepo:
 
-## Coding Style & Naming Conventions
-TypeScript files use ES modules and two-space indentation. Prefer functional React components and PascalCase filenames for components (`DoorAnimation3D.tsx`) and camelCase for hooks and utilities. Co-locate component styles with Tailwind utility classes; fall back to `App.css` or `index.css` only for global resets. Rely on the existing ESLint configuration and avoid disabling rules unless there is a documented reason in code comments.
+- `packages/door-lib/` is the publishable `retro-horror-door` library. Its
+  default API is vanilla JS + Three.js; it must remain React-free.
+- `packages/sample/` is a Vite + React app used to develop and visually verify
+  the library. The catalog lives in `src/pages/Index.tsx`, with the renderer
+  preview and modal in adjacent page modules. Historic experiments remain in
+  `src/poc/` and are routed below `/poc`.
+- `packages/door-lib/src/core/` contains framework-free types, timeline state,
+  preset selection, and texture resolution. `src/vanilla.ts` owns DOM mounting,
+  the renderer, playback, and sound.
+- Library-owned assets live in `packages/door-lib/src/assets/`; sample `public/`
+  assets are only for the sample or PoCs.
 
-## Testing Guidelines
-The project currently relies on manual verification. Before opening a pull request, exercise key flows in the local dev server—especially door-swing interactions and texture loading. When introducing regression-prone logic, add focused tests using Vitest + React Testing Library (mirror the directory being tested, e.g., `src/components/__tests__/DoorAnimation3D.test.tsx`) and document any new setup steps in the README.
+## Commands
 
-## Commit & Pull Request Guidelines
-Follow conventional commits (`feat:`, `fix:`, `chore:`) as reflected in the git history, keeping scopes short and lowercased. Each commit should address a single concern and leave the build lint-clean. Pull requests must include a summary, screenshots or short clips for UI changes, and references to related issues. Note any configuration updates or required migrations in the PR description so reviewers can verify them promptly.
+Run commands from the repository root:
+
+- `npm install`
+- `npm run dev` - start the sample app
+- `npm run build` - build library then sample
+- `npm run lint` - library typecheck and sample lint
+- `npm run test:lib:core` - core behavior tests
+- `npm run test:lib:package` - published entry and React-free boundary tests
+- `npm run test:lib:browser` - Playwright coverage for the vanilla sample and
+  catalog modal
+- `npm run verify:lib:browser` - core verification plus browser coverage
+
+## Library Conventions
+
+- Public usage is `mountDoorEntrance({ target, preset })` from
+  `retro-horror-door`.
+- A preset is a released, internally valid full door combination. Do not add a
+  public API that arbitrarily mixes motion, handle, and material.
+- Random mode chooses from registered presets and may use `type`, `motion`,
+  `handle`, and `material` only as filters. Explicit `preset` and filter fields
+  are mutually exclusive.
+- Surface assets belong to the preset: `frontTextureUrl`, `edgeTextureUrl`, and
+  `backTextureUrl`. `textureUrl` remains a legacy all-surfaces alias.
+- Do not add source videos, frame grabs, gallery thumbnails, or reference
+  metadata to the package.
+- The vanilla scene contains only door leaves and handles. Do not reintroduce a
+  frame, floor, sill, or unrelated scene geometry.
+
+## Catalog Conventions
+
+- The sample home page lists `doorEntrancePresets`; do not duplicate registry
+  data in the sample.
+- Card previews must render the actual preset at its initial state through
+  `mountDoorEntrance`. Detail playback opens in a modal, not a lower-page
+  section or a separate fake preview.
+- Keep Play, Reset, timeline seek, Escape close, overlay close, and mobile
+  close-button behavior working. Sound begins after the Play user gesture.
+
+## Testing and Pull Requests
+
+Use TypeScript with two-space indentation. Prefer focused tests in the same
+area as the behavior being changed. Library or catalog changes require the
+relevant core, package, or browser test, plus `npm run lint`; visual renderer
+changes should also be checked in the local sample app.
+
+Follow conventional commits (`feat:`, `fix:`, `docs:`, `chore:`). Pull requests
+need a concise summary, test evidence, and a screenshot or clip for UI changes.
 
 ## Evaluation Gallery
-The sibling repository `../re-door-gallery` ([GitHub](https://github.com/moojing/re-door-gallery)) is the single source of truth for door classifications, the evaluation report, and the evaluation CSV. Do not recreate tracked copies of those three files inside this repository. Any evaluation edit must target `../re-door-gallery/docs/` and be followed by `npm run gallery:check`. Gallery source videos and frame extracts are local-only under the sibling repository's ignored `materials/door-transitions/` and `materials/frame-extracts/` directories and must never be committed.
+
+The sibling `../re-door-gallery` repository is the single source of truth for
+door classification records, the report, and the estimation CSV. Do not copy
+those files here. Edit the gallery's `docs/` files and run
+`npm run gallery:check` after any evaluation-data change. Gallery source videos
+and frame extracts are local-only under ignored `materials/` directories.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,78 +1,89 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Repository layout
 
-## Repository Layout
+This is an npm workspaces monorepo:
 
-This is an **npm workspaces monorepo** with two packages:
+- `packages/door-lib/` publishes `retro-horror-door`. Its default public entry
+  is a React-free, DOM + Three.js vanilla API: `mountDoorEntrance`.
+- `packages/sample/` is a Vite + React development surface for the library.
+  React belongs to the sample only, not to the library runtime graph.
+- `docs/` contains current architecture and historical design records.
 
-- `packages/door-lib/` — the `door-entrance` library (publishable). A React Three Fiber door-opening transition component, also mountable from vanilla JS.
-- `packages/sample/` — the `door-entrance-sample` demo app (private). A Vite + React site that showcases the library and hosts its runtime assets. Deployed to GitHub Pages.
+The sample home page (`/`) is the playable preset catalog. `/poc` retains
+historic technical PoCs, and `/samples/vanilla.html` is the smallest plain
+HTML integration example.
 
-Repo-level docs live in `docs/` — notably `docs/technical-debt/` which tracks known debt items and their decisions.
+## Commands
 
-## Development Commands
+Run from the repository root:
 
-Run from the repo root:
+- `npm install`
+- `npm run dev` - start the sample app at `http://127.0.0.1:5173`
+- `npm run dev:lib` - rebuild the library in watch mode
+- `npm run build` - build the library and sample
+- `npm run lint` - typecheck the library and lint the sample
+- `npm run test:lib:core` - framework-free animation, preset, sound, and
+  controller tests
+- `npm run test:lib:package` - public export and React-free output-boundary tests
+- `npm run test:lib:browser` - Playwright coverage for the vanilla HTML mount
+  and the preset catalog modal
+- `npm run verify:lib:browser` - core verification followed by browser tests
+- `npm run gallery:check` - validate the sibling evaluation gallery after
+  changing evaluation data
 
-- `npm i` — install all workspace dependencies
-- `npm run dev` — start the sample app dev server (Vite, http://127.0.0.1:5173)
-- `npm run dev:lib` — build the library in watch mode (tsup)
-- `npm run build` — build library, then sample
-- `npm run build:lib` / `npm run build:sample` — build one package
-- `npm run lint` — ESLint (sample workspace only; the library has no lint script)
+## Library contract
 
-No test framework is configured in either package.
+- Consumers import from `retro-horror-door`:
+  `mountDoorEntrance({ target, preset: "single-lever-wood" })`.
+- A `preset` is the complete released combination of `type`, `motion`, handle,
+  material, animation, camera behavior, sound, and surface textures. Do not
+  create a separate public composition API.
+- `random: true` chooses a complete registered preset. `type`, `motion`,
+  `handle`, and `material` are filters for random selection only; do not combine
+  them with an explicit `preset`.
+- Presets can provide `frontTextureUrl`, `edgeTextureUrl`, and
+  `backTextureUrl`. Missing edge/back values inherit the front surface.
+  `textureUrl` is legacy compatibility for all three surfaces.
+- Source videos, gallery thumbnails, and classification notes are development
+  metadata. They must not enter the npm package.
+- `retro-horror-door/vanilla` remains a compatibility alias. There is no React
+  export or React peer dependency. A future React adapter must be a separate
+  package built on the existing core/vanilla contract.
 
-## Library: `packages/door-lib` (`door-entrance`)
+## Source structure
 
-- **Build**: tsup (`tsup.config.ts`), dual entry points → `dist/index.{js,cjs}` and `dist/vanilla.{js,cjs}` with `.d.ts`. Only `dist/` is published. Asset imports (`.png`/`.mp3`/`.glb`) use esbuild's `copy` loader: files are copied into `dist/` with content hashes and the import statements are preserved for the consumer's bundler to resolve.
-- **Peer deps**: `react` ^18, `@react-three/fiber` ^8, `three` ^0.133.
-- **TypeScript**: `strict: true`.
+- `packages/door-lib/src/core/`: types, animation timelines, preset selection,
+  and surface texture resolution.
+- `packages/door-lib/src/vanilla.ts`: Three.js renderer, playback controller,
+  audio scheduling, and mounted handle API.
+- `packages/door-lib/src/assets/`: library-owned texture and sound assets copied
+  into `dist/` by tsup.
+- `packages/sample/src/pages/Index.tsx`: catalog grid.
+- `packages/sample/src/pages/PresetAnimationPreview.tsx`: actual initial-frame
+  renderer on each card.
+- `packages/sample/src/pages/PresetDetailModal.tsx`: interactive vanilla
+  renderer, controls, timeline, and usage snippet.
 
-### Source structure (`src/module/`)
+The renderer intentionally creates only the door leaves and handles. Do not
+reintroduce a door frame, sill, floor, or separate fake card thumbnails.
 
-- `DoorEntrance.tsx` — main React component. Renders a full-screen R3F canvas, drives the animation timeline, plays the door sound, exposes a `DoorEntranceHandle` imperative ref, and calls `onComplete` when the transition ends.
-- `animations/` — one folder per animation variant, each exporting a config + renderer:
-  - `direct-entry` — single door swings open, camera moves through
-  - `top-down-entry` — single door viewed top-down (`single-top-down-entry` variant id)
-  - `double-swing` — double doors swing open
-  - `shared.ts` — shared helpers (easing functions, handle-press progress); `HandleModel.tsx` — GLTF door-handle loader; `animation.template.ts` — boilerplate for adding a new variant
-- `presets.ts` — preset map (`door-single`, `door-single-overhead`, `door-double`) binding a variant to default texture/handle/sound URLs (bundler-imported from `src/assets/`).
-- `handles/` — handle profile definitions (`profiles.ts`) and handle motion (`motion.ts`).
-- `assets/textures.ts` — texture manifest (resolved asset URLs) and `getTextureUrl(id)` / `pickTextureId` helpers.
-- `types.ts` — public types (`DoorAnimationVariant`, `DoorEntrancePreset`, sound progress options, etc.).
-- `vanilla.tsx` — `mountDoorEntrance(...)`, wraps the React component for non-React consumers (exported as the `door-entrance/vanilla` subpath).
+## Change and verification expectations
 
-### Assets (`src/assets/`)
+- Extend `DoorAnimationConfig` first when adding motion, then register a
+  complete preset in `src/core/presets.ts`; add assets only when project-owned
+  or generated.
+- Keep catalog previews and modal playback on the same `mountDoorEntrance`
+  path. Audio must start only after a real user Play gesture.
+- Run focused core/package/browser tests for library or catalog changes, then
+  `npm run lint` and `npm run build` before a PR.
+- Update `README.md`, `packages/sample/README.md`, and
+  `packages/door-lib/docs/ARCHITECTURE.md` when public behavior changes.
 
-Default texture/sound/handle-model files live in
-`src/assets/{textures,sounds,models}/`, each folder exporting named URLs from
-its `index.ts` (`doorWood`, `doorOpenClose`, `doorHandleSingle`). They are
-bundler imports, so the library is self-contained; history and design in
-`docs/technical-debt/door-texture-asset-ownership.md`. Consumers must treat
-`.glb` as an asset (Vite: `assetsInclude: ["**/*.glb"]`).
+## Evaluation gallery
 
-## Sample App: `packages/sample`
-
-- **Stack**: Vite + `@vitejs/plugin-react`, Tailwind CSS + shadcn/ui (`src/components/ui/`), React Router DOM, TanStack React Query, lovable-tagger (dev mode only).
-- **Vite config**: dev server on `127.0.0.1:5173`; `base` is `/re-canvas-door-swing/` in production builds (GitHub Pages); path alias `@/` → `src/`; `assetsInclude` covers `.glb` for the library's handle models.
-- **Routing**: `src/App.tsx` with `BrowserRouter basename={import.meta.env.BASE_URL}` — `/` → `pages/Index.tsx`, `*` → `pages/NotFound.tsx`.
-- **Demo code**: `src/sample/ReactSample.tsx` (React usage) and `src/sample/vanillaEntry.ts` (vanilla `mountDoorEntrance` usage), both embedded in the Index page.
-- **Assets**: `public/textures/` holds sample-only assets (e.g. `door-2.png`); the library's default presets ship their own assets (see above).
-- **TypeScript**: non-strict (`strict: false`, `noImplicitAny: false`, `strictNullChecks: false`) — unlike the library.
-
-## Conventions
-
-- Conventional commits (`feat:`, `fix:`, `chore:`, `docs:`), short lowercase scopes.
-- New animation variants: start from `animations/animation.template.ts`, register the variant in `animations/index.ts` and (optionally) a preset in `presets.ts`.
-- Verification is manual — exercise the door animations and texture/sound loading in the sample app before opening a PR.
-# Evaluation gallery
-
-The sibling repository `../re-door-gallery` is the single source of truth for the evaluation
-records and its canonical remote is https://github.com/moojing/re-door-gallery. When
-classifications, the report, or the CSV change, edit `../re-door-gallery/docs/` directly and
-run `npm run gallery:check`; the work is incomplete until that check passes. This repository
-must not track duplicate copies of those three evaluation files. Local source videos and frame
-extracts belong only in the gallery's ignored `materials/door-transitions/` and
-`materials/frame-extracts/` directories and must never be committed.
+`../re-door-gallery` is the single source of truth for classification records,
+the report, and the estimation CSV. Edit those under
+`../re-door-gallery/docs/`, then run `npm run gallery:check`. Videos and frame
+extracts remain local-only in the gallery's ignored `materials/` directories
+and must never be committed here.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Two-package workspace:
 
 - `packages/door-lib` (`retro-horror-door`): reusable retro horror door transitions with a vanilla JS API.
-- `packages/sample` (`retro-horror-door-sample`): Vite development app with PoCs and a plain HTML sample at `/samples/vanilla.html`.
+- `packages/sample` (`retro-horror-door-sample`): Vite development app. Its home page is a playable preset catalog; it also keeps the PoC gallery and a plain HTML vanilla example.
 
 ## Quick start
 
@@ -12,6 +12,12 @@ npm install
 npm run build:lib        # builds the library once (tsup)
 npm run dev              # runs the sample app (uses the built lib)
 ```
+
+Open `http://127.0.0.1:5173/` to browse every published preset. Each card
+shows the renderer's initial frame; **Open preset** opens a modal with the
+same vanilla renderer, playback controls, sound, and a seekable timeline.
+The older technical PoCs remain available at `/poc`, and the standalone HTML
+example is at `/samples/vanilla.html`.
 
 Useful scripts:
 - `npm run dev:lib` (watch build for the library)
@@ -28,17 +34,18 @@ The door library uses layered tests to keep the package framework-free:
   and controller behavior.
 - `npm run test:lib:package` checks public package exports and verifies the
   default `retro-horror-door` entry and `retro-horror-door/vanilla` output graphs are React-free.
-- `npm run test:lib:browser` runs a browser smoke test for the plain HTML sample:
-  mount, canvas rendering, controls, and lifecycle cleanup.
+- `npm run test:lib:browser` runs browser coverage for the plain HTML mount and
+  the preset catalog: canvas rendering, playback, sound, modal lifecycle,
+  timeline seeking, and the mobile close control.
 - `npm run verify:lib` / `npm run verify:lib:core` run the current green core
   verification path: library typecheck, build, and core tests.
 - `npm run verify:lib:boundary` runs the package-boundary layer.
 - `npm run verify:lib:browser` runs core verification plus the browser smoke
   tests.
 
-Current expected status: `npm run verify:lib:core` and
-`npm run verify:lib:boundary` pass. Browser verification requires local dev
-server binding and a Playwright browser runtime.
+Run `npm run verify:lib:browser` before publishing a renderer or catalog
+change. Browser verification requires local dev-server binding and an
+installed Playwright browser runtime.
 
 The library does not install or publish React, React DOM, or R3F dependencies.
 
@@ -57,7 +64,7 @@ check is stale.
 
 ## Using the library
 
-```tsx
+```ts
 import { mountDoorEntrance } from "retro-horror-door";
 
 mountDoorEntrance({

--- a/docs/technical-debt/door-texture-asset-ownership.md
+++ b/docs/technical-debt/door-texture-asset-ownership.md
@@ -1,27 +1,28 @@
 # Door Texture Asset Ownership
 
 Date: 2026-05-23
-Last updated: 2026-07-11
+Last updated: 2026-08-20
 Status: **Implemented** (see Implementation Notes below)
 
 ## Summary
 
-The `retro-horror-door` library currently defaults to a texture path of
-`textures/door-1.png`, but the actual file is hosted by the sample app at
-`packages/sample/public/textures/door-1.png`.
-
-This means the library's default behavior depends on an external consumer app
-shipping a specific static asset at a specific public URL.
+This debt is resolved. `retro-horror-door` owns its default texture and sound
+assets in `packages/door-lib/src/assets/`, and tsup copies them into the
+published `dist/` output with content hashes. Runtime presets import those
+assets directly rather than relying on `packages/sample/public/`.
 
 ## Current State
 
-- Default texture path is defined in `packages/door-lib/src/module/presets.ts` as a plain string `"textures/door-1.png"`.
-- Texture manifest in `packages/door-lib/src/module/assets/textures.ts` also uses string paths and a `getTextureUrl(id, base)` helper that prepends a consumer-supplied base URL.
-- The concrete asset currently lives in `packages/sample/public/textures/door-1.png`.
-- `packages/door-lib/package.json` only publishes `dist`, so the texture is not packaged with the library itself.
-- Sound assets have the same problem — also referenced as plain string paths.
+- `packages/door-lib/src/core/presets.ts` imports the bundled `doorWood` asset
+  and assigns it to `frontTextureUrl` for the current presets.
+- `packages/door-lib/src/vanilla.ts` resolves front, edge, and back surfaces;
+  omitted edge/back URLs inherit the front texture.
+- `packages/door-lib/src/assets/{textures,sounds}/` contains the library-owned
+  source assets. `packages/door-lib/package.json` publishes their generated
+  copies through `dist/`.
+- `packages/sample/public/` is not an implicit host for library defaults.
 
-## Why This Is Technical Debt
+## Original Problem (historical)
 
 - The library is not self-contained: a default asset is documented and assumed,
   but not actually owned by the library package.
@@ -31,7 +32,7 @@ shipping a specific static asset at a specific public URL.
 - Asset replacement becomes confusing because the authoritative source is not in
   the package that declares the default.
 
-## Risks
+## Original Risks (historical)
 
 - Published package works differently from the sample app.
 - Integrators may see missing textures in production.
@@ -53,7 +54,11 @@ CDN (jsDelivr) was considered but rejected: the pool design means the set of
 textures is fixed at build time, not runtime, so CDN's "load anything at
 runtime" advantage does not apply here.
 
-## Target Architecture
+## Original Target Architecture (historical)
+
+The sections below record the decision as it was proposed in May. The current
+implementation is described in **Current State** and **Implementation Notes**;
+the old `src/module/` paths are not part of the active codebase.
 
 ### 1. Library owns and imports its assets
 
@@ -123,7 +128,7 @@ If a consumer wants to supply their own texture URL (remote URL, their own
 public asset, or a data URL), the `textureUrl` prop continues to accept any
 string — the bundler-import default is just the fallback.
 
-## Files to Change
+## Original Files to Change (historical)
 
 | File | Change |
 |------|--------|
@@ -169,6 +174,7 @@ pass, and the sample dev server loads texture/sound/model from the library
 ## Follow-up Work (out of scope for this change)
 
 - Decide catalog size and naming convention before adding 100+ textures.
-- Add pool preload hook (`useDoorEntrance({ pool: [...] })`).
 - Validate that tree-shaking actually drops unused texture imports in a Vite consumer build.
-- Document the pool API in README (including the `assetsInclude` requirement for `.glb`).
+- Document an asset import subpath only if the public package intentionally
+  exposes one; consumers currently select complete presets rather than building
+  arbitrary runtime pools.

--- a/packages/door-lib/docs/ARCHITECTURE.md
+++ b/packages/door-lib/docs/ARCHITECTURE.md
@@ -52,6 +52,16 @@ export interface DoorAnimationConfig {
 - `random: true` 只從可用 runtime presets 中挑選；`type`、`motion`、`handle`、`material` 只在 random mode 作為篩選條件。有明確 `preset` 時不能再混用這些欄位。
 - Runtime preset registry 不包含來源影片、縮圖或分類筆記。這些只存在於 Notion / gallery / dev tracking metadata，不能進 npm package。
 
+## Sample catalog
+
+- `packages/sample` 的 `/` 是目前的 preset catalog，不再是 PoC 導覽頁。
+- 每張卡由 `PresetAnimationPreview.tsx` 以同一個 `mountDoorEntrance` renderer
+  畫出 progress `0` 的真實門板初始畫面；不可用另外維護的靜態縮圖取代。
+- 選擇卡片後，`PresetDetailModal.tsx` 會在 modal 內重新 mount 同一個 preset，
+  提供播放、重設、時間軸 seek、音效與呼叫範例。這不是捲動到頁面下方的 detail
+  section。
+- 歷史 PoC 集中在 `/poc` 與其子路徑，保留作技術實驗，不代表已發布的 runtime preset。
+
 ## 新增動畫的操作流程
 1) **新增 timeline config**：在 `src/core/animationState.ts` 新增 `id`、`label`、`description`、`duration` 與 `getState`。
 2) **登錄**：將 config 加入 `doorAnimationConfigs`，並在 `src/core/types.ts` 的 `DoorAnimationId` union 加上新 id；需要不同幾何時，再擴充 `src/vanilla.ts` 的 scene builder。
@@ -87,9 +97,11 @@ The library manifest must not expose React-related peer dependencies or a
 `retro-horror-door/react` package export.
 
 ### Browser Smoke Tests
-Run `npm run test:lib:browser` to exercise the plain HTML sample in a browser:
-the vanilla sample must mount, render a canvas, respond to controls, and clean
-up through its lifecycle.
+Run `npm run test:lib:browser` to exercise both vanilla surfaces in a browser:
+the plain HTML sample must mount and clean up, while the preset catalog must
+render real canvas previews, open and close its detail modal, support timeline
+seeking, unlock sound from the Play gesture, and keep the mobile close control
+inside the viewport.
 
 `npm run verify:lib:browser` runs the core verification path first, then the
 browser smoke tests. It requires local dev server binding and an installed

--- a/packages/sample/README.md
+++ b/packages/sample/README.md
@@ -1,73 +1,48 @@
-# Welcome to your Lovable project
+# Retro Horror Door Sample
 
-## Project info
+This Vite app is the development and visual verification surface for the
+`retro-horror-door` package. React is used only for the sample UI; every door
+canvas is mounted through the library's vanilla `mountDoorEntrance` API.
 
-**URL**: https://lovable.dev/projects/84de2ac1-9588-4d10-8d71-60ee259f20ca
+## Run locally
 
-## How can I edit this code?
-
-There are several ways of editing your application.
-
-**Use Lovable**
-
-Simply visit the [Lovable Project](https://lovable.dev/projects/84de2ac1-9588-4d10-8d71-60ee259f20ca) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
+Run these commands from the repository root:
 
 ```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
+npm install
+npm run build:lib
 npm run dev
 ```
 
-**Edit a file directly in GitHub**
+Open `http://127.0.0.1:5173/`.
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+## Routes
 
-**Use GitHub Codespaces**
+- `/`: playable preset catalog. Each card is a real initial renderer frame.
+  Selecting a card opens a modal with Play, Reset, timeline seeking, sound,
+  and the `mountDoorEntrance` usage for that preset.
+- `/poc`: historic technical PoCs. Individual POC routes remain available from
+  this gallery, but they are not the sample home page.
+- `/samples/vanilla.html`: minimal non-React mounting example.
 
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
+## Development notes
 
-## What technologies are used for this project?
+- The catalog reads `doorEntrancePresets` from the published library entry.
+  Do not duplicate the preset registry in the sample.
+- `PresetAnimationPreview.tsx` and `PresetDetailModal.tsx` both mount the
+  vanilla renderer so the preview and interactive scene use the same geometry,
+  materials, lighting, and opening behavior.
+- Library-owned default textures and sounds are bundled from
+  `packages/door-lib/src/assets/`. Files in this package's `public/` directory
+  are sample or PoC assets only.
 
-This project is built with:
+## Verification
 
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
+```sh
+npm run test:lib:browser
+npm run lint
+npm run build
+```
 
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/84de2ac1-9588-4d10-8d71-60ee259f20ca) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+The browser suite covers the catalog modal, timeline, initial canvas preview,
+audio after Play, and the standalone vanilla sample.


### PR DESCRIPTION
## Summary
- document the vanilla-first package contract and preset catalog workflow
- replace stale sample, agent, and architecture guidance
- distinguish the resolved asset-ownership state from its historical proposal

## Verification
- npm run lint (passes with 3 existing Fast Refresh warnings)
- git diff --check