### PR TITLE
feat: add full-screen transition sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,37 @@ field remains supported and applies the same texture to all three surfaces.
 Source videos,
 classification notes, and thumbnail references belong in development tracking
 docs and are not shipped in the npm package.
+
+## Full-screen page transitions
+
+For a page change, mount one viewport-sized vanilla door overlay when the app
+starts. Keep the overlay in the DOM, but hide its idle state with opacity and
+`pointer-events` rather than `display: none`. This ensures the renderer is
+already sized and ready when a user starts the transition.
+
+Call `reset()` and `play()` synchronously from the user action that triggers
+navigation. The click is necessary for browsers to permit door audio. Navigate
+only from `onComplete`, so the outgoing page remains visible until the selected
+preset has finished.
+
+```ts
+import { mountDoorEntrance } from "retro-horror-door";
+
+const overlay = document.getElementById("door-transition");
+const door = mountDoorEntrance({
+  target: overlay,
+  preset: "single-lever-wood",
+  autoPlay: false,
+  className: "h-full w-full border-0 bg-black",
+  onComplete: () => window.location.assign("/next-page"),
+});
+
+document.querySelector("#continue")?.addEventListener("click", () => {
+  const preset = "double-lever-wood";
+  overlay?.classList.add("is-visible");
+  door.reset(preset);
+  door.play(preset);
+});
+```
+
+The sample catalog includes this flow under **Full-screen page transition**.

--- a/docs/superpowers/plans/2026-08-22-full-screen-page-transition-demo.md
+++ b/docs/superpowers/plans/2026-08-22-full-screen-page-transition-demo.md
@@ -1,0 +1,196 @@
+# Full-Screen Page Transition Demo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a documented, playable sample of a selected door preset that fills the viewport and navigates only after its animation completes.
+
+**Architecture:** Keep the full-screen vanilla renderer mounted as a sibling of the catalog `main`, so the catalog can be made inert while the renderer remains focusable. `Index.tsx` owns selection and navigation, while a focused `FullScreenDoorTransition` component owns the renderer lifecycle and prevents re-entry. A separate destination route demonstrates the completed page change.
+
+**Tech Stack:** React 18, React Router, TypeScript, Tailwind CSS, `retro-horror-door` vanilla API, Playwright.
+
+---
+
+### Task 1: Define browser behavior before implementation
+
+**Files:**
+- Modify: `packages/door-lib/tests/browser/preset-catalog.test.ts`
+
+- [ ] **Step 1: Write failing full-screen transition coverage**
+
+Add Playwright coverage that:
+
+```ts
+test("catalog demo plays a selected preset full-screen before navigation", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("combobox", { name: "Transition preset" }).selectOption("double-lever-wood");
+  await page.getByRole("button", { name: "Start full-screen transition" }).click();
+  await expect(page.getByRole("status", { name: "Page transition in progress" })).toBeVisible();
+  await expect(page.getByRole("main")).toHaveAttribute("inert", "");
+  await expect(page.getByRole("status")).toBeFocused();
+  await expect(page.getByRole("status").locator("canvas")).toBeVisible();
+  await expect.poll(() => page.getByRole("status").locator("audio").evaluate((audio) => !audio.paused)).toBe(true);
+  await expect(page).toHaveURL(/\/transition-complete$/);
+  await expect(page.getByRole("heading", { name: "Destination reached" })).toBeVisible();
+  await expect(page.getByText("Double Lever Wood")).toBeVisible();
+});
+```
+
+Add tests that return with the named catalog link, directly visit
+`/transition-complete` without route state, and verify its generic copy and
+return link. Add a duplicate-click assertion that the transition control
+becomes disabled after the first start, only one transition status/canvas is
+present, and the first selected preset is the one named at the destination.
+This verifies all re-entry behavior a visitor can trigger without exposing a
+test-only transition API. After a transition starts, navigate to another sample
+route and verify the status overlay and its audio element disappear, proving
+the catalog route unmount removes the mounted renderer. Before the test loads
+the page, instrument `HTMLMediaElement.prototype.pause` with `addInitScript`
+and count pauses only when `this.closest('[role="status"]')` is present; after
+the route change assert that the transition audio pause count is positive.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run: `npm run test:lib:browser -- --grep "full-screen transition"`
+
+Expected: FAIL because the combobox, status region, and destination route do
+not exist.
+
+### Task 2: Implement the reusable fullscreen renderer layer
+
+**Files:**
+- Create: `packages/sample/src/components/FullScreenDoorTransition.tsx`
+
+- [ ] **Step 1: Implement the public ref contract**
+
+Export a `FullScreenDoorTransitionHandle` with:
+
+```ts
+play: (request: {
+  preset: DoorEntrancePresetId;
+  destination: string;
+}) => void;
+```
+
+Use `forwardRef` and mount `mountDoorEntrance` once into a full-viewport target
+in `useEffect`, with `autoPlay: false` and a `className` that fills the target.
+The wrapper is fixed with an explicit high z-index. Idle state stays mounted,
+viewport-sized, transparent, `pointer-events: none`, and `aria-hidden`; active
+state is opaque, receives pointer blocking, and is not `aria-hidden`. It must
+never use `display: none`.
+
+- [ ] **Step 2: Implement interaction isolation and re-entry protection**
+
+When `play` is called, use a ref-backed running guard, retain the first
+`destination` alongside its preset, call `door.reset(preset)` then
+`door.play(preset)` synchronously after revealing the layer, focus its
+`tabIndex={-1}` status wrapper from a `useLayoutEffect` keyed to the committed
+active state, and call `onActiveChange(true)`. Keep `door.play()` in the click
+path so its sound unlock remains a user gesture. Ignore calls while running.
+Set `role="status"`,
+`aria-label="Page transition in progress"`, and `aria-live="polite"` on the
+wrapper.
+
+On the single `onComplete`, call `onComplete({ preset, destination })`. Clean
+up audio and the renderer with `unmount()` on component unmount.
+
+- [ ] **Step 3: Run the focused test to verify progress**
+
+Run: `npm run test:lib:browser -- --grep "full-screen transition"`
+
+Expected: it still fails until the catalog trigger and destination route exist,
+but the status region and canvas assertions can now be satisfied manually.
+
+### Task 3: Add the catalog demonstration and destination page
+
+**Files:**
+- Modify: `packages/sample/src/pages/Index.tsx`
+- Create: `packages/sample/src/pages/TransitionComplete.tsx`
+- Modify: `packages/sample/src/App.tsx`
+
+- [ ] **Step 1: Add the transition demo band**
+
+Place an unframed full-width section after the catalog grid. Build its select
+options directly from `doorEntrancePresets`, label it `Transition preset`, and
+give the command button the accessible name `Start full-screen transition`.
+Keep this state separate from the preset-detail selection.
+
+- [ ] **Step 2: Connect the mounted overlay**
+
+Render `FullScreenDoorTransition` as a sibling of the catalog `main`. Give the
+catalog main a ref; set or remove its `inert` attribute through an
+`onActiveChange` callback. Disable the demo command after the first click. Call
+`transitionRef.current.play({ preset, destination: "/transition-complete" })`;
+on completion, use the returned destination for `navigate(destination, {
+state: { presetId } })`.
+
+- [ ] **Step 3: Create the completed destination**
+
+Use `useLocation` to read the optional preset id, resolve its label with
+`doorEntrancePresetMap`, and render the heading `Destination reached`. Add a
+React Router `Link` named `Return to preset catalog` to `/`. Direct visits use
+generic copy rather than throwing on missing state.
+
+- [ ] **Step 4: Register the route**
+
+Add `/transition-complete` in `App.tsx` before the catch-all route.
+
+- [ ] **Step 5: Run the focused browser test to verify GREEN**
+
+Run: `npm run test:lib:browser -- --grep "full-screen transition"`
+
+Expected: PASS. Confirm the status canvas appears before the destination URL,
+the catalog is inert while active, the destination names the chosen preset, and
+the return link works.
+
+### Task 4: Document the integration lifecycle
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the framework-neutral README example**
+
+Document a fixed overlay that exists before a link is clicked. The example must
+mount with `autoPlay: false`, set the layer to full viewport dimensions, call
+`reset(selectedPreset)` and `play(selectedPreset)` inside a click handler, and
+navigate only from `onComplete`. Explain why the hidden layer uses opacity and
+pointer-events rather than `display: none`, and why a click gesture is required
+for sound.
+
+### Task 5: Full verification
+
+**Files:**
+- Test: `packages/door-lib/tests/browser/preset-catalog.test.ts`
+
+- [ ] **Step 1: Run browser coverage**
+
+Run: `npm run test:lib:browser`
+
+Expected: all existing tests plus transition coverage pass.
+
+- [ ] **Step 2: Run package boundary tests**
+
+Run: `npm run test:lib:package`
+
+Expected: package remains React-free and all boundary tests pass.
+
+- [ ] **Step 3: Run lint and production build**
+
+Run: `npm run lint`
+
+Run: `npm run build`
+
+Expected: no errors. Report the three existing Fast Refresh warnings if they
+remain.
+
+- [ ] **Step 4: Inspect the visual result**
+
+Run the sample dev server and verify the full-screen layer fills desktop and
+mobile viewports, contains no frame or catalog UI during playback, plays sound
+from the click, reaches the destination, and returns to the catalog.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md packages/sample/src/components/FullScreenDoorTransition.tsx packages/sample/src/pages/Index.tsx packages/sample/src/pages/TransitionComplete.tsx packages/sample/src/App.tsx packages/door-lib/tests/browser/preset-catalog.test.ts docs/superpowers/specs/2026-08-21-full-screen-page-transition-demo-design.md docs/superpowers/plans/2026-08-22-full-screen-page-transition-demo.md
+git commit -m "feat: add full-screen transition sample"
+```

--- a/docs/superpowers/specs/2026-08-21-full-screen-page-transition-demo-design.md
+++ b/docs/superpowers/specs/2026-08-21-full-screen-page-transition-demo-design.md
@@ -1,0 +1,137 @@
+# Full-Screen Page Transition Demo Design
+
+**Date:** 2026-08-21
+
+## Goal
+
+Document and demonstrate how a site can play a selected `retro-horror-door`
+preset across the full viewport before it navigates to the next page.
+
+## Scope
+
+- Add a dedicated transition-demo card below the sample preset catalog.
+- Let the visitor choose one registered preset and start a real full-screen
+  transition from a user click.
+- Navigate to `/transition-complete` only after the animation finishes.
+- Provide a return button on `/transition-complete` back to the catalog.
+- Add a framework-neutral README example using the same lifecycle.
+- Add browser coverage for overlay display, navigation after completion, and
+  returning to the catalog.
+
+The existing preset detail modal remains an inspection and playback surface.
+It will not gain a second full-screen transition control.
+
+## Interaction Design
+
+The catalog gets one unframed full-width transition-demo band after the preset
+grid. It contains a native select menu populated from `doorEntrancePresets`,
+a short explanation, and one clear command button: **Start full-screen
+transition**.
+
+When the button is clicked:
+
+1. The fullscreen layer becomes visible above the catalog.
+2. The selected preset begins from progress zero with its sound.
+3. The catalog below becomes `inert`, and focus moves to the fullscreen layer,
+   so keyboard interaction cannot reach controls behind the transition. The
+   layer is a programmatically focusable (`tabIndex={-1}`) named status region
+   with `aria-live="polite"` and the announcement “Page transition in
+   progress”.
+4. After the renderer invokes `onComplete`, React Router navigates to
+   `/transition-complete`.
+5. The destination page shows the selected preset label and a **Return to
+   preset catalog** button.
+
+The transition intentionally has no cancel control. It is a page-change
+commitment rather than a preview modal.
+
+## Architecture
+
+### Persistent transition layer
+
+Create `packages/sample/src/components/FullScreenDoorTransition.tsx`. It owns
+one full-viewport target and mounts `mountDoorEntrance` exactly once when the
+catalog page loads. It renders as a sibling of the catalog `main`, never inside
+the subtree that becomes `inert`. While idle the layer remains mounted and
+viewport-sized but is visually transparent and has no pointer interaction; it
+must not use `display: none`, because the renderer needs dimensions before
+playback.
+
+The component exposes an imperative `play({ preset, destination })` method to
+its parent. On the trigger button's click handler, `Index.tsx` calls this
+method synchronously. The method stores the destination in a ref, reveals the
+layer, resets the renderer to the selected preset, then calls `play(preset)`.
+Calling `play` inside the actual click handler preserves browser user
+activation so the opening sound can unlock and play.
+
+The component keeps an internal running guard. Once a transition starts it
+ignores further `play` calls until completion or unmount; the catalog command
+button also becomes disabled immediately. This prevents a second click from
+replacing the selected preset or destination. `onComplete` is processed once.
+
+At completion, the component uses the stored destination and invokes its
+`onComplete` callback. `Index.tsx` navigates with React Router to
+`/transition-complete`, passing the selected preset id in location state. The
+component cleanup unmounts the vanilla renderer when the catalog route itself
+unmounts.
+
+### Sample pages
+
+`Index.tsx` owns the selected demo preset id and renders the demo band plus the
+persistent `FullScreenDoorTransition`. It continues to render actual canvas
+previews and the existing detail modal unchanged.
+
+Create `packages/sample/src/pages/TransitionComplete.tsx` for the destination
+route. It derives a readable preset label from route state when present and
+falls back to a generic destination confirmation for a direct visit. Its return
+control is a React Router `Link` to `/`.
+
+`App.tsx` registers `/transition-complete`.
+
+### README
+
+Add a **Full-screen page transitions** section to the root README. It shows a
+framework-neutral pattern:
+
+- create a fixed, viewport-sized overlay at application startup;
+- mount the door renderer into that overlay with `autoPlay: false`;
+- reveal the overlay and call `door.play()` within the link/button click;
+- navigate from `onComplete`.
+
+The example uses opacity and pointer-events to hide the mounted layer rather
+than `display: none`. It gives the overlay viewport dimensions before mounting,
+calls `reset(selectedPreset)` before `play(selectedPreset)`, and clearly states
+that `play()` should be invoked from a user gesture to allow sound.
+
+## Error and Cleanup Behavior
+
+- The renderer mounts synchronously and can play immediately. Texture and audio
+  assets load progressively, so the demo command does not need an artificial
+  readiness delay.
+- If the catalog unmounts before completion, the component unmounts its
+  renderer and leaves no audio or animation frame running.
+- A direct visit to `/transition-complete` remains valid and has a working
+  return control even without route state.
+- The renderer's texture and audio loading are progressive: a failed asset may
+  degrade its appearance or silence its sound, but the opening timeline still
+  completes and the visitor is not stranded behind the overlay. The library
+  exposes no asset-error callback, so the sample does not invent a retry state.
+
+## Tests
+
+Extend `packages/door-lib/tests/browser/preset-catalog.test.ts`:
+
+1. Verify the demo select and start button are available, then begin a
+   transition.
+2. Choose `double-lever-wood`, start the transition, and verify the fullscreen
+   transition canvas becomes visible before navigation, the catalog is inert,
+   and the transition audio starts from the click path.
+3. Wait for `/transition-complete`, verify the selected preset label and return
+   button, then return to `/`.
+4. Verify repeated start clicks do not create a second transition or change the
+   destination; verify an in-progress route unmount cleans up the transition.
+5. Preserve the existing catalog/modal, timeline, audio, and mobile-close
+   coverage.
+
+Run `npm run test:lib:browser`, `npm run test:lib:package`, `npm run lint`,
+and `npm run build` before the implementation PR.

--- a/packages/door-lib/tests/browser/preset-catalog.test.ts
+++ b/packages/door-lib/tests/browser/preset-catalog.test.ts
@@ -25,7 +25,7 @@ test("preset catalog opens and closes a vanilla detail modal", async ({
   await page.getByRole("button", { name: "Close preset detail" }).click();
 
   await expect(dialog).toHaveCount(0);
-  await expect(page.locator("canvas")).toHaveCount(3);
+  await expect(page.locator("canvas")).toHaveCount(4);
 });
 
 test("preset detail lets users scrub the animation timeline", async ({
@@ -63,4 +63,63 @@ test("mobile preset detail keeps its close control within the viewport", async (
   expect(bounds).not.toBeNull();
   expect(bounds?.x).toBeGreaterThanOrEqual(0);
   expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(390);
+});
+
+test("full-screen transition plays the selected preset before navigating", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByLabel("Transition preset").selectOption("double-lever-wood");
+  await page
+    .getByRole("button", { name: "Start full-screen transition" })
+    .click();
+
+  const transition = page.getByRole("status", {
+    name: "Page transition in progress",
+  });
+  await expect(transition).toBeVisible();
+  await expect(transition).toBeFocused();
+  await expect(transition.locator("canvas")).toBeVisible();
+  await expect(page.getByRole("main")).toHaveAttribute("inert", "");
+  await expect(transition.locator("audio")).toHaveJSProperty("paused", false);
+
+  await expect(page).toHaveURL(/\/transition-complete$/, { timeout: 10_000 });
+  await expect(
+    page.getByRole("heading", { name: "Destination reached" })
+  ).toBeVisible();
+  await expect(page.getByText("Double Lever Wood", { exact: true })).toBeVisible();
+
+  await page.getByRole("link", { name: "Return to preset catalog" }).click();
+  await expect(page).toHaveURL(/\/$/);
+});
+
+test("full-screen transition does not start a second run", async ({ page }) => {
+  await page.goto("/");
+  await page.getByLabel("Transition preset").selectOption("double-lever-wood");
+
+  const startButton = page.getByRole("button", {
+    name: "Start full-screen transition",
+  });
+  await startButton.click();
+
+  await expect(startButton).toBeDisabled();
+  await expect(
+    page.getByRole("status", { name: "Page transition in progress" })
+  ).toHaveCount(1);
+  await expect(
+    page.getByRole("status", { name: "Page transition in progress" }).locator("canvas")
+  ).toHaveCount(1);
+});
+
+test("transition destination has a direct-visit fallback", async ({ page }) => {
+  await page.goto("/transition-complete");
+
+  await expect(
+    page.getByRole("heading", { name: "Destination reached" })
+  ).toBeVisible();
+  await expect(page.getByText("No preset was selected", { exact: true })).toBeVisible();
+
+  await page.getByRole("link", { name: "Return to preset catalog" }).click();
+  await expect(page).toHaveURL(/\/$/);
 });

--- a/packages/sample/src/App.tsx
+++ b/packages/sample/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import TransitionComplete from "./pages/TransitionComplete";
 import NotFound from "./pages/NotFound";
 import A04DoorPoC from "./poc/A04DoorPoC";
 import HeavyWaterDoorA11 from "./poc/HeavyWaterDoorA11";
@@ -24,6 +25,7 @@ const App = () => (
       <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/transition-complete" element={<TransitionComplete />} />
           <Route path="/poc" element={<PocGallery />} />
           <Route path="/poc/a04" element={<A04DoorPoC />} />
           <Route path="/poc/a11" element={<HeavyWaterDoorA11 />} />

--- a/packages/sample/src/components/FullScreenDoorTransition.tsx
+++ b/packages/sample/src/components/FullScreenDoorTransition.tsx
@@ -1,0 +1,116 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  mountDoorEntrance,
+  type DoorEntranceHandle,
+  type DoorEntrancePresetId,
+} from "retro-horror-door";
+
+export type FullScreenDoorTransitionRequest = {
+  preset: DoorEntrancePresetId;
+  destination: string;
+};
+
+export type FullScreenDoorTransitionHandle = {
+  play: (request: FullScreenDoorTransitionRequest) => void;
+};
+
+type FullScreenDoorTransitionProps = {
+  onActiveChange: (active: boolean) => void;
+  onComplete: (request: FullScreenDoorTransitionRequest) => void;
+};
+
+const FullScreenDoorTransition = forwardRef<
+  FullScreenDoorTransitionHandle,
+  FullScreenDoorTransitionProps
+>(({ onActiveChange, onComplete }, ref) => {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const regionRef = useRef<HTMLDivElement>(null);
+  const doorRef = useRef<DoorEntranceHandle | null>(null);
+  const requestRef = useRef<FullScreenDoorTransitionRequest | null>(null);
+  const runningRef = useRef(false);
+  const completedRef = useRef(false);
+  const onActiveChangeRef = useRef(onActiveChange);
+  const onCompleteRef = useRef(onComplete);
+  const [active, setActive] = useState(false);
+
+  onActiveChangeRef.current = onActiveChange;
+  onCompleteRef.current = onComplete;
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    const door = mountDoorEntrance({
+      target,
+      preset: "single-lever-wood",
+      autoPlay: false,
+      className: "h-full w-full border-0 bg-black",
+      onComplete: () => {
+        const request = requestRef.current;
+        if (!runningRef.current || completedRef.current || !request) return;
+
+        completedRef.current = true;
+        runningRef.current = false;
+        onActiveChangeRef.current(false);
+        setActive(false);
+        onCompleteRef.current(request);
+      },
+    });
+    doorRef.current = door;
+
+    return () => {
+      door.unmount();
+      doorRef.current = null;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (active) regionRef.current?.focus();
+  }, [active]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      play: (request) => {
+        const door = doorRef.current;
+        if (!door || runningRef.current) return;
+
+        runningRef.current = true;
+        completedRef.current = false;
+        requestRef.current = request;
+        onActiveChangeRef.current(true);
+        setActive(true);
+        door.reset(request.preset);
+        door.play(request.preset);
+      },
+    }),
+    []
+  );
+
+  return (
+    <div
+      ref={regionRef}
+      role="status"
+      aria-label="Page transition in progress"
+      aria-live="polite"
+      aria-hidden={active ? undefined : true}
+      tabIndex={-1}
+      className={`fixed inset-0 z-[100] bg-black transition-opacity duration-150 ${
+        active ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
+      }`}
+    >
+      <div ref={targetRef} className="absolute inset-0" />
+    </div>
+  );
+});
+
+FullScreenDoorTransition.displayName = "FullScreenDoorTransition";
+
+export default FullScreenDoorTransition;

--- a/packages/sample/src/pages/Index.tsx
+++ b/packages/sample/src/pages/Index.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ArrowUpRight } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import {
   doorEntrancePresets,
   type DoorEntrancePresetId,
 } from "retro-horror-door";
+import FullScreenDoorTransition, {
+  type FullScreenDoorTransitionHandle,
+} from "@/components/FullScreenDoorTransition";
 import PresetDetailModal from "./PresetDetailModal";
 import PresetAnimationPreview from "./PresetAnimationPreview";
 
@@ -14,15 +18,32 @@ const formatValue = (value: string) =>
     .join(" ");
 
 const Index = () => {
+  const navigate = useNavigate();
+  const transitionRef = useRef<FullScreenDoorTransitionHandle>(null);
   const [selectedPresetId, setSelectedPresetId] =
     useState<DoorEntrancePresetId | null>(null);
+  const [transitionPresetId, setTransitionPresetId] =
+    useState<DoorEntrancePresetId>(doorEntrancePresets[0].id);
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const selectedPreset = doorEntrancePresets.find(
     (preset) => preset.id === selectedPresetId
   );
   const closeDetail = useCallback(() => setSelectedPresetId(null), []);
+  const startTransition = () => {
+    if (isTransitioning) return;
+
+    transitionRef.current?.play({
+      preset: transitionPresetId,
+      destination: "/transition-complete",
+    });
+  };
 
   return (
-    <main className="min-h-screen bg-[#070504] text-[#e9dfcd]">
+    <>
+    <main
+      inert={isTransitioning ? "" : undefined}
+      className="min-h-screen bg-[#070504] text-[#e9dfcd]"
+    >
       <div className="mx-auto w-full max-w-7xl px-5 py-12 sm:px-8 sm:py-16 lg:px-10 lg:py-20">
         <header className="max-w-3xl border-l border-[#b77a38]/70 pl-5 sm:pl-7">
           <p className="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[#c58a45]">
@@ -94,12 +115,70 @@ const Index = () => {
               </article>
           ))}
         </section>
+
+        <section
+          aria-labelledby="transition-demo-title"
+          className="mt-14 border-y border-[#5f4933]/60 py-8 sm:mt-20 sm:py-10"
+        >
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end lg:gap-10">
+            <div className="max-w-2xl">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-[#c98d48]">
+                App navigation demo
+              </p>
+              <h2
+                id="transition-demo-title"
+                className="mt-3 font-[Georgia,serif] text-3xl text-[#f1e7d6] sm:text-4xl"
+              >
+                Full-screen page transition
+              </h2>
+              <p className="mt-3 text-sm leading-7 text-[#aa9f90] sm:text-base">
+                Choose a released preset, then use its actual vanilla animation before arriving at the next page.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-[minmax(220px,1fr)_auto] lg:min-w-[520px]">
+              <label className="grid gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-[#aa9f90]">
+                Transition preset
+                <select
+                  aria-label="Transition preset"
+                  value={transitionPresetId}
+                  disabled={isTransitioning}
+                  onChange={(event) =>
+                    setTransitionPresetId(event.target.value as DoorEntrancePresetId)
+                  }
+                  className="min-h-11 border border-[#5f4933] bg-[#0c0907] px-3 text-sm font-normal normal-case tracking-normal text-[#e9dfcd] focus:outline-none focus:ring-2 focus:ring-[#d39952] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {doorEntrancePresets.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                disabled={isTransitioning}
+                onClick={startTransition}
+                className="min-h-11 self-end border border-[#c98d48] bg-[#c98d48] px-5 text-sm font-bold text-[#100c08] transition-colors hover:bg-[#dda762] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-offset-4 focus-visible:ring-offset-[#070504] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Start full-screen transition
+              </button>
+            </div>
+          </div>
+        </section>
       </div>
 
       {selectedPreset && (
         <PresetDetailModal preset={selectedPreset} onClose={closeDetail} />
       )}
     </main>
+      <FullScreenDoorTransition
+        ref={transitionRef}
+        onActiveChange={setIsTransitioning}
+        onComplete={({ preset, destination }) =>
+          navigate(destination, { state: { presetId: preset } })
+        }
+      />
+    </>
   );
 };
 

--- a/packages/sample/src/pages/TransitionComplete.tsx
+++ b/packages/sample/src/pages/TransitionComplete.tsx
@@ -1,0 +1,49 @@
+import { ArrowLeft } from "lucide-react";
+import { Link, useLocation } from "react-router-dom";
+import {
+  doorEntrancePresetMap,
+  type DoorEntrancePresetId,
+} from "retro-horror-door";
+
+type TransitionLocationState = {
+  presetId?: DoorEntrancePresetId;
+};
+
+const TransitionComplete = () => {
+  const location = useLocation();
+  const state = location.state as TransitionLocationState | null;
+  const preset = state?.presetId
+    ? doorEntrancePresetMap[state.presetId]
+    : undefined;
+
+  return (
+    <main className="grid min-h-screen place-items-center bg-[#070504] px-5 py-10 text-[#e9dfcd] sm:px-8">
+      <section className="w-full max-w-xl border border-[#5f4933]/70 bg-[#0c0907] p-7 sm:p-10">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-[#c98d48]">
+          Door transition
+        </p>
+        <h1 className="mt-4 font-[Georgia,serif] text-4xl leading-tight text-[#f1e7d6] sm:text-5xl">
+          Destination reached
+        </h1>
+        {preset ? (
+          <p className="mt-5 text-base leading-7 text-[#cfc0ac]">
+            Completed with <span className="font-semibold text-[#f1e7d6]">{preset.label}</span>.
+          </p>
+        ) : (
+          <p className="mt-5 text-base leading-7 text-[#cfc0ac]">
+            <span>No preset was selected</span>. Return to the catalog to start a door transition.
+          </p>
+        )}
+        <Link
+          to="/"
+          className="mt-8 inline-flex items-center gap-2 border border-[#c98d48] px-4 py-2.5 text-sm font-semibold text-[#e8bc82] transition-colors hover:bg-[#c98d48] hover:text-[#100c08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-offset-4 focus-visible:ring-offset-[#0c0907]"
+        >
+          <ArrowLeft aria-hidden="true" size={16} />
+          Return to preset catalog
+        </Link>
+      </section>
+    </main>
+  );
+};
+
+export default TransitionComplete;


### PR DESCRIPTION
## Summary
- add a selectable, vanilla-rendered full-screen page transition to the sample catalog
- add a transition destination with a catalog return control
- document the lifecycle and cover transition behavior in Playwright

## Verification
- npm run test:lib:browser
- npm run test:lib:package
- npm run lint
- npm run build

## Visual
- verified the catalog transition band and destination page locally