### PR TITLE
fix: load library source in sample development

### DIFF
--- a/packages/sample/vite.config.test.mjs
+++ b/packages/sample/vite.config.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const configUrl = new URL("./vite.config.ts", import.meta.url);
+
+test("uses the library source while developing the sample", async () => {
+  const source = await readFile(fileURLToPath(configUrl), "utf8");
+
+  assert.match(
+    source,
+    /"retro-horror-door": path\.resolve\(__dirname, "\.\.\/door-lib\/src\/index\.ts"\)/
+  );
+});

--- a/packages/sample/vite.config.ts
+++ b/packages/sample/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "retro-horror-door": path.resolve(__dirname, "../door-lib/src/index.ts"),
     },
   },
 }));


### PR DESCRIPTION
## Summary
- resolve `retro-horror-door` to its source entry during sample development
- add a regression test so the sample cannot silently load stale `dist` output

## Verification
- `node --test packages/sample/vite.config.test.mjs`
- `npm run lint`
- `npm run build:sample`
- `npm run test:lib:browser` (8 passed)

The visual regression was reproduced on `http://127.0.0.1:5180` and confirmed resolved after rebuilding/restarting the sample.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a path alias so the sample app can reference the library source directly.

* **Tests**
  * Added automated coverage to verify that the alias resolves to the expected library entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->