### PR TITLE
feat: add sample header links

### DIFF
--- a/docs/superpowers/plans/2026-08-22-sample-header-links.md
+++ b/docs/superpowers/plans/2026-08-22-sample-header-links.md
@@ -1,0 +1,33 @@
+# Sample Header Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add minimal external documentation and stakeholder-picker links above the sample preset catalog.
+
+**Architecture:** Keep the home page as the single owner of the header because the links only describe the catalog surface. Add one focused source-level test that verifies each named anchor has its own expected destination and safe external-link behavior; do not change library APIs or catalog data.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, Node test runner, Vite.
+
+---
+
+### Task 1: Define the header-link contract
+
+**Files:**
+- Create: `packages/sample/src/pages/Index.header.test.mjs`
+- Modify: `packages/sample/src/pages/Index.tsx`
+
+- [ ] Write a failing Node test that reads `Index.tsx` and matches the complete `GitHub README` anchor and complete `Stakeholder picker` anchor independently. Each match must include its expected URL, `target="_blank"`, and `rel="noreferrer"`.
+- [ ] Run `node --test packages/sample/src/pages/Index.header.test.mjs`; it must fail before the header exists.
+- [ ] Add a flex header before the existing catalog heading. Use `justify-between` to keep the compact product name at the left and a wrapping link group at the right on desktop; allow the whole header to wrap on narrow screens. Use the existing palette, visible labels, and `ArrowUpRight`.
+- [ ] Re-run `node --test packages/sample/src/pages/Index.header.test.mjs`; it must pass.
+- [ ] Commit the test and `Index.tsx` with `feat: add sample header links`.
+
+### Task 2: Verify the catalog remains usable
+
+**Files:**
+- Modify: none
+
+- [ ] Run `npm run lint` and `npm run build:sample`; expect exit 0 with only existing Fast Refresh warnings.
+- [ ] Run `npm run test:lib:browser`; expect modal playback and full-screen transition coverage to pass.
+- [ ] Inspect the home page at desktop and mobile widths. Confirm both links are visible, wrap cleanly, and leave catalog controls usable.
+- [ ] Check `git status --short` to confirm no implementation files are unstaged.

--- a/docs/superpowers/plans/2026-08-22-sample-header-links.md
+++ b/docs/superpowers/plans/2026-08-22-sample-header-links.md
@@ -16,18 +16,18 @@
 - Create: `packages/sample/src/pages/Index.header.test.mjs`
 - Modify: `packages/sample/src/pages/Index.tsx`
 
-- [ ] Write a failing Node test that reads `Index.tsx` and matches the complete `GitHub README` anchor and complete `Stakeholder picker` anchor independently. Each match must include its expected URL, `target="_blank"`, and `rel="noreferrer"`.
-- [ ] Run `node --test packages/sample/src/pages/Index.header.test.mjs`; it must fail before the header exists.
-- [ ] Add a flex header before the existing catalog heading. Use `justify-between` to keep the compact product name at the left and a wrapping link group at the right on desktop; allow the whole header to wrap on narrow screens. Use the existing palette, visible labels, and `ArrowUpRight`.
-- [ ] Re-run `node --test packages/sample/src/pages/Index.header.test.mjs`; it must pass.
-- [ ] Commit the test and `Index.tsx` with `feat: add sample header links`.
+- [x] Write a failing Node test that reads `Index.tsx` and matches the complete `GitHub README` anchor and complete `Stakeholder picker` anchor independently. Each match must include its expected URL, `target="_blank"`, and `rel="noreferrer"`.
+- [x] Run `node --test packages/sample/src/pages/Index.header.test.mjs`; it must fail before the header exists.
+- [x] Add a flex header before the existing catalog heading. Use `justify-between` to keep the compact product name at the left and a wrapping link group at the right on desktop; allow the whole header to wrap on narrow screens. Use the existing palette, visible labels, and `ArrowUpRight`.
+- [x] Re-run `node --test packages/sample/src/pages/Index.header.test.mjs`; it must pass.
+- [x] Commit the test and `Index.tsx` with `feat: add sample header links`.
 
 ### Task 2: Verify the catalog remains usable
 
 **Files:**
 - Modify: none
 
-- [ ] Run `npm run lint` and `npm run build:sample`; expect exit 0 with only existing Fast Refresh warnings.
-- [ ] Run `npm run test:lib:browser`; expect modal playback and full-screen transition coverage to pass.
-- [ ] Inspect the home page at desktop and mobile widths. Confirm both links are visible, wrap cleanly, and leave catalog controls usable.
-- [ ] Check `git status --short` to confirm no implementation files are unstaged.
+- [x] Run `npm run lint` and `npm run build:sample`; expect exit 0 with only existing Fast Refresh warnings.
+- [x] Run `npm run test:lib:browser`; expect modal playback and full-screen transition coverage to pass.
+- [x] Inspect the home page at desktop and mobile widths. Confirm both links are visible, wrap cleanly, and leave catalog controls usable.
+- [x] Check `git status --short` to confirm no implementation files are unstaged.

--- a/docs/superpowers/specs/2026-08-22-sample-header-links-design.md
+++ b/docs/superpowers/specs/2026-08-22-sample-header-links-design.md
@@ -1,0 +1,23 @@
+# Sample Header Links Design
+
+## Goal
+
+Add a compact header above the preset catalog so visitors can reach the project documentation and the stakeholder image picker.
+
+## Confirmed Design
+
+Use the selected minimal-header layout: a small `Retro Horror Door` wordmark on the left and two text links on the right. On desktop, the header uses `justify-between` so the wordmark and right-side link group remain at opposite edges; the link group itself may wrap. Each link includes a small external-arrow icon, as shown in the selected preview. The header sits inside the existing centered page container, above the current catalog heading. On narrow screens, its contents wrap without overlapping.
+
+## Links
+
+- `GitHub README` links to `https://github.com/moojing/re-canvas-door-swing#readme`.
+- `Stakeholder picker` links to `https://re-door-gallery.pages.dev/stakeholder-selection`.
+- Both are external links and open in a new tab with `rel="noreferrer"`.
+
+## Scope
+
+The existing preset cards, modal playback, full-screen transition, and page routing remain unchanged. The implementation is limited to the sample home page and a focused source-level regression test for the two links.
+
+## Verification
+
+The test will assert that each named link has its own expected URL and safe external-link attributes. Existing lint, sample build, and library browser tests will verify that the catalog and playback still work.

--- a/packages/sample/src/pages/Index.header.test.mjs
+++ b/packages/sample/src/pages/Index.header.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const indexPath = new URL("./Index.tsx", import.meta.url);
+
+const requiredLinks = [
+  {
+    label: "GitHub README",
+    href: "https://github.com/moojing/re-canvas-door-swing#readme",
+  },
+  {
+    label: "Stakeholder picker",
+    href: "https://re-door-gallery.pages.dev/stakeholder-selection",
+  },
+];
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const anchorPattern = ({ label, href }) =>
+  new RegExp(
+    `<a\\b(?=[^>]*\\bhref=["']${escapeRegExp(href)}["'])(?=[^>]*\\btarget=["']_blank["'])(?=[^>]*\\brel=["']noreferrer["'])[^>]*>[\\s\\S]*?${escapeRegExp(label)}[\\s\\S]*?<\\/a>`
+  );
+
+test("catalog header exposes the required external links", async () => {
+  const source = await readFile(indexPath, "utf8");
+
+  for (const { label, href } of requiredLinks) {
+    assert.match(source, anchorPattern({ label, href }), `expected a complete external anchor for ${label}`);
+  }
+});
+
+test("anchor matcher rejects a near-match URL", () => {
+  const [{ label, href }] = requiredLinks;
+  const malformedAnchor = `<a href="${href.replace("github.com", "githubXcom")}" target="_blank" rel="noreferrer">${label}</a>`;
+
+  assert.doesNotMatch(malformedAnchor, anchorPattern({ label, href }));
+});

--- a/packages/sample/src/pages/Index.tsx
+++ b/packages/sample/src/pages/Index.tsx
@@ -45,7 +45,33 @@ const Index = () => {
       className="min-h-screen bg-[#070504] text-[#e9dfcd]"
     >
       <div className="mx-auto w-full max-w-7xl px-5 py-12 sm:px-8 sm:py-16 lg:px-10 lg:py-20">
-        <header className="max-w-3xl border-l border-[#b77a38]/70 pl-5 sm:pl-7">
+        <header className="flex flex-wrap items-center justify-between gap-4 border-b border-[#5f4933]/60 pb-5">
+          <p className="font-[Georgia,serif] text-xl text-[#f1e7d6]">
+            Retro Horror Door
+          </p>
+          <nav aria-label="Project links" className="flex flex-wrap gap-x-5 gap-y-2 text-xs font-semibold uppercase tracking-[0.14em] sm:justify-end">
+            <a
+              href="https://github.com/moojing/re-canvas-door-swing#readme"
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 text-[#c98d48] transition-colors hover:text-[#f0bd78] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-offset-4 focus-visible:ring-offset-[#070504]"
+            >
+              GitHub README
+              <ArrowUpRight aria-hidden="true" size={14} />
+            </a>
+            <a
+              href="https://re-door-gallery.pages.dev/stakeholder-selection"
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 text-[#c98d48] transition-colors hover:text-[#f0bd78] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-offset-4 focus-visible:ring-offset-[#070504]"
+            >
+              Stakeholder picker
+              <ArrowUpRight aria-hidden="true" size={14} />
+            </a>
+          </nav>
+        </header>
+
+        <header className="mt-10 max-w-3xl border-l border-[#b77a38]/70 pl-5 sm:mt-14 sm:pl-7">
           <p className="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[#c58a45]">
             Retro Horror Door / {String(doorEntrancePresets.length).padStart(2, "0")} presets
           </p>


### PR DESCRIPTION
## Summary
- add a compact sample header with links to the GitHub README and stakeholder picker
- keep the selected minimal layout responsive across desktop and mobile widths
- add focused coverage for the exact external-link contract

## Verification
- `node --test packages/sample/src/pages/Index.header.test.mjs`
- `npm run lint`
- `npm run build:sample`
- `npm run test:lib:browser` (8 passed)
- manual desktop and 390px mobile visual checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a project header to the sample home page featuring the “Retro Horror Door” label.
  - Added quick links to the GitHub README and stakeholder picker.
  - External links open safely in new tabs and adapt to narrow screens.

- **Documentation**
  - Added design and implementation documentation for the new header and links.

- **Tests**
  - Added coverage verifying link destinations, labels, and safe external-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->