### PR TITLE
feat: add developer animation verify pages

### DIFF
--- a/docs/superpowers/plans/2026-08-23-dev-animation-verify.md
+++ b/docs/superpowers/plans/2026-08-23-dev-animation-verify.md
@@ -1,0 +1,33 @@
+# Developer Animation Verify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sample-only `/dev/animations` pages that inspect one published animation and switch among presets that share it.
+
+**Architecture:** Keep grouping in a sample helper over `doorAnimationConfigs` and `doorEntrancePresets`. List and verifier pages stay out of the library. The client catalog at `/` does not gain a Dev link.
+
+**Tech Stack:** React Router, `mountDoorEntrance`, Node test runner
+
+---
+
+### Task 1: Animation preset helper
+
+**Files:**
+- Create: `packages/sample/src/dev/animationPresets.ts`
+- Create: `packages/sample/src/dev/animationPresets.test.ts`
+
+- [x] Write failing tests for known-animation check, presets grouped by animation, first-preset fallback, mismatched-preset fallback, and empty animation.
+- [x] Implement the helper and make the tests pass.
+
+### Task 2: Routes and pages
+
+**Files:**
+- Create: `packages/sample/src/pages/DevAnimationList.tsx`
+- Create: `packages/sample/src/pages/DevAnimationVerifier.tsx`
+- Create: `packages/sample/src/pages/devAnimationRoutes.test.mjs`
+- Modify: `packages/sample/src/App.tsx`
+- Modify: `packages/sample/src/pages/Index.header.test.mjs`
+
+- [x] Lock `/dev` → `/dev/animations`, verifier route, 404 for unknown animation, and no `/dev` link in the catalog header.
+- [x] Add the list and verifier pages. Verifier remounts `mountDoorEntrance({ preset })`, keeps Play/Reset/timeline, and does not mount when no presets exist.
+- [x] Run helper + route tests, `npm run lint`, and a browser pass of `/dev/animations` plus `/`.

--- a/docs/superpowers/specs/2026-08-23-dev-animation-verify-design.md
+++ b/docs/superpowers/specs/2026-08-23-dev-animation-verify-design.md
@@ -1,0 +1,54 @@
+# Developer Animation Verify Pages
+
+## Goal
+
+Give developers a sample-only surface to inspect one door animation at a time
+and switch among published presets that share that animation. Keep the client
+catalog at `/` unchanged.
+
+## Non-goals
+
+- Do not add a public library API that mixes animation, handle, and texture.
+- Do not add unpublished skins, gallery frames, or file-upload texture swapping.
+- Do not put a Dev link on the client catalog header.
+- Do not reuse `/poc`; those routes stay historic PoCs.
+
+## Routes
+
+- `/dev` redirects to `/dev/animations`.
+- `/dev/animations` lists every `doorAnimationConfigs` entry in registry order.
+  Each row links to `/dev/animations/:animationId` and shows how many published
+  presets use that animation.
+- `/dev/animations/:animationId` is the verifier for one animation.
+- Unknown `animationId` renders the existing sample 404 page.
+- `/dev/animations/:animationId?preset=<presetId>` selects that preset when it
+  belongs to the animation; an unknown or mismatched preset falls back to the
+  first published preset for that animation.
+
+## Verifier page
+
+- Label the page as developer verify, not the client catalog.
+- Mount one large `mountDoorEntrance` player for the selected published preset.
+  Keep Play, Reset, timeline seek, and audio-after-Play.
+- Show a switcher of published presets where `preset.animation === animationId`.
+  Switching updates the `preset` query param and remounts the same animation
+  through `mountDoorEntrance({ target, preset })`.
+- If only one preset exists for that animation, the switcher still shows it.
+- If no published preset uses that animation, show an empty state and do not
+  call `mountDoorEntrance`. Never fall through to the library default preset.
+- Link back to `/dev/animations`.
+
+## Data
+
+- Read animations from `doorAnimationConfigs`.
+- Read presets from `doorEntrancePresets`.
+- Derive the switcher with a sample-local helper; do not invent presets in the
+  sample that are missing from the library registry.
+
+## Verification
+
+- Source or unit tests lock the two routes, the `/dev` redirect, grouping by
+  animation, and the mismatched-preset fallback.
+- Browser or equivalent UI check: open `/dev/animations`, enter one animation,
+  play, and confirm the client catalog at `/` still has no Dev header link.
+- `npm run lint` and the sample production build succeed.

--- a/packages/sample/src/App.tsx
+++ b/packages/sample/src/App.tsx
@@ -2,9 +2,11 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Navigate, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import TransitionComplete from "./pages/TransitionComplete";
+import DevAnimationList from "./pages/DevAnimationList";
+import DevAnimationVerifier from "./pages/DevAnimationVerifier";
 import NotFound from "./pages/NotFound";
 import A04DoorPoC from "./poc/A04DoorPoC";
 import HeavyWaterDoorA11 from "./poc/HeavyWaterDoorA11";
@@ -25,6 +27,9 @@ const App = () => (
       <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/dev" element={<Navigate to="/dev/animations" replace />} />
+          <Route path="/dev/animations" element={<DevAnimationList />} />
+          <Route path="/dev/animations/:animationId" element={<DevAnimationVerifier />} />
           <Route path="/transition-complete" element={<TransitionComplete />} />
           <Route path="/poc" element={<PocGallery />} />
           <Route path="/poc/a04" element={<A04DoorPoC />} />

--- a/packages/sample/src/dev/animationPresets.test.ts
+++ b/packages/sample/src/dev/animationPresets.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isKnownAnimation,
+  presetsForAnimation,
+  resolveVerifierPreset,
+} from "./animationPresets.ts";
+
+const animations = ["direct-entry", "single-top-down-entry", "double-swing"];
+const presets = [
+  { id: "single-lever-wood", animation: "direct-entry" },
+  { id: "single-overhead-lever-wood", animation: "single-top-down-entry" },
+  { id: "double-lever-wood", animation: "double-swing" },
+];
+
+test("recognizes registered animation ids only", () => {
+  assert.equal(isKnownAnimation("direct-entry", animations), true);
+  assert.equal(isKnownAnimation("unknown-entry", animations), false);
+});
+
+test("groups published presets by animation", () => {
+  assert.deepEqual(presetsForAnimation("direct-entry", presets), [
+    presets[0],
+  ]);
+  assert.deepEqual(presetsForAnimation("double-swing", presets), [
+    presets[2],
+  ]);
+});
+
+test("falls back to the first preset for a missing or mismatched id", () => {
+  assert.equal(
+    resolveVerifierPreset("direct-entry", presets),
+    presets[0]
+  );
+  assert.equal(
+    resolveVerifierPreset("direct-entry", presets, "not-a-preset"),
+    presets[0]
+  );
+  assert.equal(
+    resolveVerifierPreset("direct-entry", presets, "double-lever-wood"),
+    presets[0]
+  );
+});
+
+test("returns null when an animation has no published presets", () => {
+  assert.equal(resolveVerifierPreset("direct-entry", []), null);
+  assert.deepEqual(presetsForAnimation("direct-entry", []), []);
+});

--- a/packages/sample/src/dev/animationPresets.ts
+++ b/packages/sample/src/dev/animationPresets.ts
@@ -1,0 +1,22 @@
+export const isKnownAnimation = (
+  animationId: string,
+  animationIds: Iterable<string>
+) => new Set(animationIds).has(animationId);
+
+export const presetsForAnimation = <
+  T extends { animation: string },
+>(
+  animationId: string,
+  presets: readonly T[]
+) => presets.filter((preset) => preset.animation === animationId);
+
+export const resolveVerifierPreset = <
+  T extends { id: string; animation: string },
+>(
+  animationId: string,
+  presets: readonly T[],
+  presetId?: string | null
+) => {
+  const matches = presetsForAnimation(animationId, presets);
+  return matches.find((preset) => preset.id === presetId) ?? matches[0] ?? null;
+};

--- a/packages/sample/src/pages/DevAnimationList.tsx
+++ b/packages/sample/src/pages/DevAnimationList.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+import {
+  doorAnimationConfigs,
+  doorEntrancePresets,
+} from "retro-horror-door";
+import { presetsForAnimation } from "@/dev/animationPresets";
+
+const DevAnimationList = () => (
+  <main className="min-h-screen bg-[#070504] px-5 py-10 text-[#e9dfcd] sm:px-8">
+    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[#c58a45]">
+      Developer verify
+    </p>
+    <h1 className="mt-3 font-[Georgia,serif] text-4xl text-[#f1e7d6]">
+      Animations
+    </h1>
+    <ul className="mt-10 grid gap-3">
+      {doorAnimationConfigs.map((animation) => {
+        const count = presetsForAnimation(animation.id, doorEntrancePresets)
+          .length;
+        return (
+          <li key={animation.id}>
+            <Link
+              to={`/dev/animations/${animation.id}`}
+              className="flex items-center justify-between border border-[#5f4933]/60 bg-[#0c0907] px-5 py-4 hover:border-[#c98d48]"
+            >
+              <span>
+                <span className="block font-[Georgia,serif] text-xl text-[#eee2d0]">
+                  {animation.label}
+                </span>
+                <span className="mt-1 block font-mono text-xs text-[#a89d8e]">
+                  {animation.id}
+                </span>
+              </span>
+              <span className="text-xs uppercase tracking-[0.14em] text-[#c98d48]">
+                {count} {count === 1 ? "preset" : "presets"}
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  </main>
+);
+
+export default DevAnimationList;

--- a/packages/sample/src/pages/DevAnimationVerifier.tsx
+++ b/packages/sample/src/pages/DevAnimationVerifier.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import {
+  doorAnimationConfigs,
+  doorEntrancePresets,
+  getDoorAnimationConfig,
+  mountDoorEntrance,
+  type DoorEntranceHandle,
+} from "retro-horror-door";
+import {
+  isKnownAnimation,
+  presetsForAnimation,
+  resolveVerifierPreset,
+} from "@/dev/animationPresets";
+import NotFound from "./NotFound";
+
+const formatTime = (milliseconds: number) => {
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  return `${String(Math.floor(totalSeconds / 60)).padStart(2, "0")}:${String(totalSeconds % 60).padStart(2, "0")}`;
+};
+
+const DevAnimationVerifier = () => {
+  const { animationId = "" } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const targetRef = useRef<HTMLDivElement>(null);
+  const doorRef = useRef<DoorEntranceHandle | null>(null);
+  const [ready, setReady] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const animationIds = doorAnimationConfigs.map(({ id }) => id);
+  const known = isKnownAnimation(animationId, animationIds);
+  const animation = known ? getDoorAnimationConfig(animationId) : null;
+  const presets = known
+    ? presetsForAnimation(animationId, doorEntrancePresets)
+    : [];
+  const preset = known
+    ? resolveVerifierPreset(animationId, presets, searchParams.get("preset"))
+    : null;
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target || !preset) return;
+
+    setReady(false);
+    setProgress(0);
+    const door = mountDoorEntrance({
+      target,
+      preset: preset.id,
+      autoPlay: false,
+      className: "h-full min-h-[360px] w-full border-0 bg-black",
+      onReady: () => setReady(true),
+      onProgress: setProgress,
+    });
+    doorRef.current = door;
+
+    return () => {
+      door.unmount();
+      doorRef.current = null;
+    };
+  }, [preset]);
+
+  if (!known || !animation) {
+    return <NotFound />;
+  }
+
+  return (
+    <main className="min-h-screen bg-[#070504] px-5 py-8 text-[#e9dfcd] sm:px-8">
+      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[#c58a45]">
+        Developer verify
+      </p>
+      <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+        <h1 className="font-[Georgia,serif] text-4xl text-[#f1e7d6]">
+          {animation.label}
+        </h1>
+        <Link
+          to="/dev/animations"
+          className="text-xs font-semibold uppercase tracking-[0.14em] text-[#c98d48]"
+        >
+          All animations
+        </Link>
+      </div>
+
+      {!preset ? (
+        <p className="mt-10 text-[#aa9f90]">
+          No published presets for this animation.
+        </p>
+      ) : (
+        <div className="mt-8 flex flex-col gap-6">
+          <div className="relative min-h-[56vh] bg-black sm:min-h-[64vh]">
+            <div ref={targetRef} className="absolute inset-0" />
+          </div>
+          <div>
+            <p className="font-mono text-xs text-[#aa9f90]">{preset.id}</p>
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                onClick={() => doorRef.current?.play(preset.id)}
+                disabled={!ready}
+                className="border border-[#c98d48] bg-[#c98d48] px-4 py-2 text-sm font-bold text-[#100c08] disabled:opacity-50"
+              >
+                Play
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setProgress(0);
+                  doorRef.current?.reset(preset.id);
+                }}
+                className="border border-[#8d683e] px-4 py-2 text-sm font-semibold text-[#ddc6a8]"
+              >
+                Reset
+              </button>
+            </div>
+            <section className="mt-4 border-y border-[#4b3928] py-4" aria-label="Animation timeline">
+              <div className="flex justify-between text-xs text-[#aa9f90]">
+                <span>{formatTime(animation.duration * progress)}</span>
+                <span>{formatTime(animation.duration)}</span>
+              </div>
+              <input
+                aria-label="Animation progress"
+                type="range"
+                min="0"
+                max="100"
+                step="0.1"
+                value={progress * 100}
+                disabled={!ready}
+                onChange={(event) => {
+                  const next = Number(event.target.value) / 100;
+                  setProgress(next);
+                  doorRef.current?.seek(next, preset.id);
+                }}
+                className="mt-2 h-2 w-full accent-[#c98d48]"
+              />
+            </section>
+            <h2 className="mt-5 text-xs font-semibold uppercase tracking-[0.14em] text-[#827665]">
+              Published presets
+            </h2>
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {presets.map((option) => (
+                <li key={option.id}>
+                  <button
+                    type="button"
+                    aria-pressed={option.id === preset.id}
+                    onClick={() => setSearchParams({ preset: option.id })}
+                    className={`border px-3 py-2 text-sm ${
+                      option.id === preset.id
+                        ? "border-[#c98d48] text-[#f1e7d6]"
+                        : "border-[#5f4933] text-[#d8c9b5]"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+};
+
+export default DevAnimationVerifier;

--- a/packages/sample/src/pages/Index.header.test.mjs
+++ b/packages/sample/src/pages/Index.header.test.mjs
@@ -45,3 +45,9 @@ test("catalog header stays at the top while the page scrolls", async () => {
     /<header className="[^\"]*\bsticky\b[^\"]*\btop-0\b[^\"]*">/
   );
 });
+
+test("catalog header does not expose a developer verify link", async () => {
+  const source = await readFile(indexPath, "utf8");
+
+  assert.doesNotMatch(source, /\/dev\/animations/);
+});

--- a/packages/sample/src/pages/devAnimationRoutes.test.mjs
+++ b/packages/sample/src/pages/devAnimationRoutes.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const appPath = new URL("../App.tsx", import.meta.url);
+const indexPath = new URL("./Index.tsx", import.meta.url);
+
+test("registers developer animation routes before the catch-all", async () => {
+  const source = await readFile(appPath, "utf8");
+
+  assert.match(source, /path="\/dev"[\s\S]*Navigate[\s\S]*to="\/dev\/animations"/);
+  assert.match(source, /path="\/dev\/animations"/);
+  assert.match(source, /path="\/dev\/animations\/:animationId"/);
+  assert.match(
+    source,
+    /path="\/dev\/animations\/:animationId"[\s\S]*path="\*"/
+  );
+});
+
+test("catalog header does not expose a Dev link", async () => {
+  const source = await readFile(indexPath, "utf8");
+
+  assert.doesNotMatch(source, /\/dev\/animations/);
+  assert.doesNotMatch(source, />Dev</);
+});


### PR DESCRIPTION
## Summary
- Add sample-only `/dev` → `/dev/animations` list and `/dev/animations/:animationId` verifier.
- Switch among published presets that share one animation via `mountDoorEntrance({ preset })`.
- Keep the client catalog header unchanged (no Dev link).

## Test plan
- [x] Helper + route tests
- [x] `npm run lint --workspace retro-horror-door-sample`
- [x] Browser: list, play, unknown animation 404, mismatched preset fallback
- [ ] After merge, `/dev/animations` is reachable on GitHub Pages by URL only


Made with [Cursor](https://cursor.com)