### PR TITLE
feat: preview animations on the list and collapse header links on mobile

### DIFF
--- a/packages/sample/src/components/SampleHeader.tsx
+++ b/packages/sample/src/components/SampleHeader.tsx
@@ -1,84 +1,72 @@
 import { ArrowUpRight } from "lucide-react";
 import { Link } from "react-router-dom";
-import { doorAnimationConfigs } from "retro-horror-door";
-import { shouldCollapseAnimationLinks } from "@/dev/animationPresets";
 
 const linkClassName =
   "flex items-center gap-1.5 text-[#c98d48] transition-colors hover:text-[#f0bd78] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-offset-4 focus-visible:ring-offset-[#070504]";
 const menuLinkClassName =
-  "block px-3 py-2 text-[#d8c9b5] hover:bg-[#16110d] hover:text-[#f1e7d6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-inset";
+  "flex items-center gap-1.5 px-3 py-2 text-[#d8c9b5] hover:bg-[#16110d] hover:text-[#f1e7d6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d39952] focus-visible:ring-inset";
 
-const SampleHeader = () => {
-  const animations = doorAnimationConfigs;
-  const dropdown = shouldCollapseAnimationLinks(doorAnimationConfigs.length);
+const headerLinks = [
+  {
+    label: "GitHub README",
+    href: "https://github.com/moojing/re-canvas-door-swing#readme",
+  },
+  {
+    label: "Stakeholder picker",
+    href: "https://re-door-gallery.pages.dev/stakeholder-selection",
+  },
+  {
+    label: "Animations",
+    to: "/dev/animations",
+  },
+] as const;
 
-  return (
-    <header className="sticky top-0 z-40 -mx-5 flex flex-wrap items-center justify-between gap-4 border-b border-[#5f4933]/60 bg-[#070504]/95 px-5 py-4 backdrop-blur sm:-mx-8 sm:px-8 lg:-mx-10 lg:px-10">
-      <Link to="/" className="font-[Georgia,serif] text-xl text-[#f1e7d6]">
-        Retro Horror Door
-      </Link>
-      <nav
-        aria-label="Project links"
-        className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-semibold uppercase tracking-[0.14em] sm:justify-end"
-      >
-        <a
-          href="https://github.com/moojing/re-canvas-door-swing#readme"
-          target="_blank"
-          rel="noreferrer"
-          className={linkClassName}
-        >
-          GitHub README
-          <ArrowUpRight aria-hidden="true" size={14} />
-        </a>
-        <a
-          href="https://re-door-gallery.pages.dev/stakeholder-selection"
-          target="_blank"
-          rel="noreferrer"
-          className={linkClassName}
-        >
-          Stakeholder picker
-          <ArrowUpRight aria-hidden="true" size={14} />
-        </a>
-        {dropdown ? (
-          <details className="relative">
-            <summary className={`${linkClassName} cursor-pointer list-none [&::-webkit-details-marker]:hidden`}>
-              Animations
-            </summary>
-            <ul className="absolute right-0 z-50 mt-2 min-w-[14rem] border border-[#5f4933] bg-[#0c0907] py-2 normal-case tracking-normal">
-              {animations.map((animation) => (
-                <li key={animation.id}>
-                  <Link
-                    to={`/dev/animations/${animation.id}`}
-                    className={menuLinkClassName}
-                  >
-                    {animation.label}
-                  </Link>
-                </li>
-              ))}
-              <li>
-                <Link
-                  to="/dev/animations"
-                  className={`${menuLinkClassName} border-t border-[#4b3928] text-[#c98d48]`}
-                >
-                  All animations
-                </Link>
-              </li>
-            </ul>
-          </details>
-        ) : (
-          animations.map((animation) => (
-            <Link
-              key={animation.id}
-              to={`/dev/animations/${animation.id}`}
-              className={linkClassName}
-            >
-              {animation.label}
-            </Link>
-          ))
-        )}
-      </nav>
-    </header>
+const HeaderLink = ({
+  link,
+  className,
+}: {
+  link: (typeof headerLinks)[number];
+  className: string;
+}) =>
+  "to" in link ? (
+    <Link to={link.to} className={className}>
+      {link.label}
+    </Link>
+  ) : (
+    <a href={link.href} target="_blank" rel="noreferrer" className={className}>
+      {link.label}
+      <ArrowUpRight aria-hidden="true" size={14} />
+    </a>
   );
-};
+
+const SampleHeader = () => (
+  <header className="sticky top-0 z-40 -mx-5 flex items-center justify-between gap-4 border-b border-[#5f4933]/60 bg-[#070504]/95 px-5 py-4 backdrop-blur sm:-mx-8 sm:px-8 lg:-mx-10 lg:px-10">
+    <Link to="/" className="shrink-0 font-[Georgia,serif] text-xl text-[#f1e7d6]">
+      Retro Horror Door
+    </Link>
+    <nav
+      aria-label="Project links"
+      className="text-xs font-semibold uppercase tracking-[0.14em]"
+    >
+      <div className="hidden items-center gap-x-5 sm:flex">
+        {headerLinks.map((link) => (
+          <HeaderLink key={link.label} link={link} className={linkClassName} />
+        ))}
+      </div>
+      <details className="relative sm:hidden">
+        <summary className={`${linkClassName} cursor-pointer list-none [&::-webkit-details-marker]:hidden`}>
+          More
+        </summary>
+        <ul className="absolute right-0 z-50 mt-2 min-w-[14rem] border border-[#5f4933] bg-[#0c0907] py-2 normal-case tracking-normal">
+          {headerLinks.map((link) => (
+            <li key={link.label}>
+              <HeaderLink link={link} className={menuLinkClassName} />
+            </li>
+          ))}
+        </ul>
+      </details>
+    </nav>
+  </header>
+);
 
 export default SampleHeader;

--- a/packages/sample/src/dev/animationPresets.test.ts
+++ b/packages/sample/src/dev/animationPresets.test.ts
@@ -4,13 +4,7 @@ import {
   isKnownAnimation,
   presetsForAnimation,
   resolveVerifierPreset,
-  shouldCollapseAnimationLinks,
 } from "./animationPresets.ts";
-
-test("uses a header dropdown once animation links overflow", () => {
-  assert.equal(shouldCollapseAnimationLinks(2), false);
-  assert.equal(shouldCollapseAnimationLinks(3), true);
-});
 
 const animations = ["direct-entry", "single-top-down-entry", "double-swing"];
 const presets = [

--- a/packages/sample/src/dev/animationPresets.ts
+++ b/packages/sample/src/dev/animationPresets.ts
@@ -1,8 +1,3 @@
-export const INLINE_HEADER_ANIMATION_LIMIT = 2;
-
-export const shouldCollapseAnimationLinks = (count: number) =>
-  count > INLINE_HEADER_ANIMATION_LIMIT;
-
 export const isKnownAnimation = (
   animationId: string,
   animationIds: Iterable<string>

--- a/packages/sample/src/pages/DevAnimationList.tsx
+++ b/packages/sample/src/pages/DevAnimationList.tsx
@@ -5,6 +5,7 @@ import {
 } from "retro-horror-door";
 import SampleHeader from "@/components/SampleHeader";
 import { presetsForAnimation } from "@/dev/animationPresets";
+import PresetAnimationPreview from "./PresetAnimationPreview";
 
 const DevAnimationList = () => (
   <main className="min-h-screen bg-[#070504] px-5 py-10 text-[#e9dfcd] sm:px-8 lg:px-10">
@@ -15,26 +16,37 @@ const DevAnimationList = () => (
     <h1 className="mt-3 font-[Georgia,serif] text-4xl text-[#f1e7d6]">
       Animations
     </h1>
-    <ul className="mt-10 grid gap-3">
+    <ul className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
       {doorAnimationConfigs.map((animation) => {
-        const count = presetsForAnimation(animation.id, doorEntrancePresets)
-          .length;
+        const presets = presetsForAnimation(animation.id, doorEntrancePresets);
+        const preview = presets[0];
         return (
           <li key={animation.id}>
             <Link
               to={`/dev/animations/${animation.id}`}
-              className="flex items-center justify-between border border-[#5f4933]/60 bg-[#0c0907] px-5 py-4 hover:border-[#c98d48]"
+              className="flex h-full flex-col overflow-hidden border border-[#5f4933]/60 bg-[#0c0907] hover:border-[#c98d48]"
             >
-              <span>
-                <span className="block font-[Georgia,serif] text-xl text-[#eee2d0]">
-                  {animation.label}
+              <div className="relative h-56 overflow-hidden border-b border-[#5f4933]/45 bg-[#090705]">
+                {preview ? (
+                  <PresetAnimationPreview preset={preview} progress={0.4} />
+                ) : (
+                  <p className="flex h-full items-center justify-center px-4 text-sm text-[#aa9f90]">
+                    No published presets
+                  </p>
+                )}
+              </div>
+              <span className="flex items-end justify-between gap-3 p-5">
+                <span>
+                  <span className="block font-[Georgia,serif] text-xl text-[#eee2d0]">
+                    {animation.label}
+                  </span>
+                  <span className="mt-1 block font-mono text-xs text-[#a89d8e]">
+                    {animation.id}
+                  </span>
                 </span>
-                <span className="mt-1 block font-mono text-xs text-[#a89d8e]">
-                  {animation.id}
+                <span className="shrink-0 text-xs uppercase tracking-[0.14em] text-[#c98d48]">
+                  {presets.length} {presets.length === 1 ? "preset" : "presets"}
                 </span>
-              </span>
-              <span className="text-xs uppercase tracking-[0.14em] text-[#c98d48]">
-                {count} {count === 1 ? "preset" : "presets"}
               </span>
             </Link>
           </li>

--- a/packages/sample/src/pages/Index.header.test.mjs
+++ b/packages/sample/src/pages/Index.header.test.mjs
@@ -32,8 +32,10 @@ test("header exposes the required external links", async () => {
   const source = await readFile(headerPath, "utf8");
 
   for (const { label, href } of requiredLinks) {
-    assert.match(source, anchorPattern({ label, href }), `expected a complete external anchor for ${label}`);
+    assert.match(source, new RegExp(`label: "${escapeRegExp(label)}"`));
+    assert.match(source, new RegExp(`href: "${escapeRegExp(href)}"`));
   }
+  assert.match(source, /<a href=\{link\.href\} target="_blank" rel="noreferrer"/);
 });
 
 test("anchor matcher rejects a near-match URL", () => {
@@ -52,11 +54,12 @@ test("header stays at the top while the page scrolls", async () => {
   );
 });
 
-test("header lists animations and collapses overflow into a dropdown", async () => {
+test("header sends Animations to the list and collapses non-home links on small screens", async () => {
   const source = await readFile(headerPath, "utf8");
 
-  assert.match(source, /shouldCollapseAnimationLinks\(doorAnimationConfigs\.length\)/);
-  assert.match(source, /\/dev\/animations\/\$\{animation\.id\}/);
-  assert.match(source, /<details/);
-  assert.match(source, /to="\/dev\/animations"/);
+  assert.match(source, /to: "\/dev\/animations"/);
+  assert.doesNotMatch(source, /\/dev\/animations\/\$\{/);
+  assert.match(source, /hidden items-center gap-x-5 sm:flex/);
+  assert.match(source, /relative sm:hidden/);
+  assert.match(source, />\s*More\s*</);
 });

--- a/packages/sample/src/pages/PresetAnimationPreview.tsx
+++ b/packages/sample/src/pages/PresetAnimationPreview.tsx
@@ -7,9 +7,13 @@ import {
 
 type PresetAnimationPreviewProps = {
   preset: DoorEntrancePreset;
+  progress?: number;
 };
 
-const PresetAnimationPreview = ({ preset }: PresetAnimationPreviewProps) => {
+const PresetAnimationPreview = ({
+  preset,
+  progress = 0,
+}: PresetAnimationPreviewProps) => {
   const targetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -22,9 +26,10 @@ const PresetAnimationPreview = ({ preset }: PresetAnimationPreviewProps) => {
       autoPlay: false,
       className: "h-full min-h-0 w-full border-0 bg-black",
     });
+    if (progress) door.seek(progress);
 
     return () => door.unmount();
-  }, [preset.id]);
+  }, [preset.id, progress]);
 
   return (
     <div

--- a/packages/sample/src/pages/devAnimationRoutes.test.mjs
+++ b/packages/sample/src/pages/devAnimationRoutes.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const appPath = new URL("../App.tsx", import.meta.url);
 const indexPath = new URL("./Index.tsx", import.meta.url);
+const listPath = new URL("./DevAnimationList.tsx", import.meta.url);
 
 test("registers developer animation routes before the catch-all", async () => {
   const source = await readFile(appPath, "utf8");
@@ -21,4 +22,11 @@ test("catalog page mounts the shared sample header", async () => {
   const source = await readFile(indexPath, "utf8");
 
   assert.match(source, /<SampleHeader\s*\/>/);
+});
+
+test("animation list previews the first published preset for each animation", async () => {
+  const source = await readFile(listPath, "utf8");
+
+  assert.match(source, /<PresetAnimationPreview preset=\{preview\} progress=\{0\.4\} \/>/);
+  assert.match(source, /const preview = presets\[0\]/);
 });


### PR DESCRIPTION
## Summary
- Show a real `mountDoorEntrance` thumbnail for each animation on `/dev/animations`, using the first published preset at 40% progress.
- Send header **Animations** to the list page, and collapse GitHub / Stakeholder / Animations into a **More** menu on small screens.

## Test plan
- [x] `node --test packages/sample/src/pages/devAnimationRoutes.test.mjs packages/sample/src/pages/Index.header.test.mjs`
- [x] `node --disable-warning=ExperimentalWarning --experimental-strip-types --test packages/sample/src/dev/animationPresets.test.ts`
- [x] `npm run lint --workspace retro-horror-door-sample`
- [x] Browser: `/dev/animations` desktop + mobile thumbs, card opens verifier, header returns to list, catalog previews still mount


Made with [Cursor](https://cursor.com)